### PR TITLE
Automate TWIR summary notifications

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,42 @@
-- name: Send latest post to Telegram
-  env:
-    TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-    TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-  run: |
-    latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n1)
-    last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
-    if [ "$latest_post" != "$last_sent" ]; then
-      text=$(cat "$latest_post")
-      curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-        -d "chat_id=${TELEGRAM_CHAT_ID}" \
-        --data-urlencode "text=$text"
-      echo "$latest_post" > last_sent.txt
-      git config user.name github-actions
-      git config user.email github-actions@github.com
-      git add last_sent.txt
-      git commit -m "Update last_sent.txt"
-      git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:master
-    else
-      echo "No new release. Skipping Telegram notification."
-    fi
+name: Send TWIR summary
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout TWIR
+        uses: actions/checkout@v4
+        with:
+          repository: rust-lang/this-week-in-rust
+          path: twir
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Send latest post to Telegram
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n1)
+          last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
+          if [ "$latest_post" != "$last_sent" ]; then
+            text=$(cargo run -- "$latest_post")
+            curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+              -d "chat_id=${TELEGRAM_CHAT_ID}" \
+              --data-urlencode "text=$text" \
+              -d "parse_mode=Markdown"
+            echo "$latest_post" > last_sent.txt
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git add last_sent.txt
+            git commit -m "Update last_sent.txt"
+            git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:master
+          else
+            echo "No new release. Skipping Telegram notification."
+          fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 use regex::Regex;
-use std::fs;
+use std::{env, fs};
 
 fn main() -> std::io::Result<()> {
-    let input = fs::read_to_string("input.md")?;
+    let args: Vec<String> = env::args().collect();
+    let input_path = args.get(1).map(String::as_str).unwrap_or("input.md");
+    let input = fs::read_to_string(input_path)?;
     let mut output = String::new();
 
     // Заголовок и дата
@@ -52,7 +54,8 @@ fn main() -> std::io::Result<()> {
     output.push_str("\n---\n\n");
     output.push_str("_Полный выпуск: ссылка_\n");
 
-    fs::write("output.md", output)?;
+    fs::write("output.md", &output)?;
+    println!("{}", output);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- extend Rust tool to read an input file path and print the result
- schedule a workflow that checks the This Week in Rust repository daily and posts updates to Telegram

## Testing
- `cargo build --quiet` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685c7d309e488332a3b432609b8edafe