### PR TITLE
Fix rust action path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
           repository: rust-lang/this-week-in-rust
           path: twir
 
-      - uses: actions/setup-rust@v1
+      - uses: rust-lang/setup-rust@v1
         with:
           rust-version: stable
 


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow by using `rust-lang/setup-rust@v1`

## Testing
- `cargo test` *(fails: unable to fetch crates index)*

------
https://chatgpt.com/codex/tasks/task_e_685c80700c208332af2fb2f84bcd2b5b