### PR TITLE
Fix workflow commit order

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,12 @@ jobs:
               --data-urlencode "text=$text" \
               -d "parse_mode=Markdown"
             echo "$latest_post" > last_sent.txt
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            git pull --rebase
-            git add last_sent.txt
-            git commit -m "Update last_sent.txt"
-            git push
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add last_sent.txt
+          git commit -m "Update last_sent.txt"
+          git pull --rebase
+          git push
           else
             echo "No new release. Skipping Telegram notification."
           fi

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# TWIR Deploy Notify
+
+This repository contains a small tool and workflow for sending summaries of the latest **This Week in Rust** post to Telegram.
+
+The GitHub Actions workflow checks out the [`rust-lang/this-week-in-rust`](https://github.com/rust-lang/this-week-in-rust) repository and detects the newest Markdown file in its `content` directory. If a new issue is found, it is parsed with the Rust application in `src/main.rs`, and the generated message is posted to the configured Telegram chat.
+
+To run the workflow locally you must clone the `this-week-in-rust` repository into a `twir` subdirectory:
+
+```bash
+git clone https://github.com/rust-lang/this-week-in-rust twir
+```
+
+After that you can run the tool manually with:
+
+```bash
+cargo run -- twir/content/<file-name>.md
+```
+
+The workflow keeps track of the last processed file in `last_sent.txt`.


### PR DESCRIPTION
## Summary
- reorder steps in workflow to avoid unstaged changes error
- add README explaining how to run locally

## Testing
- `cargo build` *(failed: unable to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685c828082408332bd12ece397da84d3