### PR TITLE
Fix parsing for TWIR sections

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,8 @@ fn main() -> std::io::Result<()> {
     }
 
     // Разделы и ссылки
-    let section_re = Regex::new(r"(?m)^##+ ([^\n]+)\n").unwrap();
-    let link_re = Regex::new(r"^\* \[(.+?)\]\((.+?)\)").unwrap();
+    let section_re = Regex::new(r"^##+\s+(.+)$").unwrap();
+    let link_re = Regex::new(r"^[*-] \[(.+?)\]\((.+?)\)").unwrap();
 
     let mut lines = input.lines().peekable();
     let mut in_section = false;


### PR DESCRIPTION
## Summary
- fix the regexes detecting sections and links in `src/main.rs`

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo test` *(fails: could not download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_685d2202beb0833282cf987007d00920