### PR TITLE
Split TWIR summary into multiple telegram posts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,11 +32,15 @@ jobs:
           latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n1)
           last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
           if [ "$latest_post" != "$last_sent" ]; then
-            text=$(cargo run -- "$latest_post")
-            curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-              -d "chat_id=${TELEGRAM_CHAT_ID}" \
-              --data-urlencode "text=$text" \
-              -d "parse_mode=Markdown"
+            rm -f output_*.md
+            cargo run -- "$latest_post"
+            for file in $(ls -v output_*.md 2>/dev/null); do
+              text=$(cat "$file")
+              curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+                -d "chat_id=${TELEGRAM_CHAT_ID}" \
+                --data-urlencode "text=$text" \
+                -d "parse_mode=Markdown"
+            done
             echo "$latest_post" > last_sent.txt
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a small tool and workflow for sending summaries of the latest **This Week in Rust** post to Telegram.
 
-The GitHub Actions workflow checks out the [`rust-lang/this-week-in-rust`](https://github.com/rust-lang/this-week-in-rust) repository and detects the newest Markdown file in its `content` directory. If a new issue is found, it is parsed with the Rust application in `src/main.rs`, and the generated message is posted to the configured Telegram chat.
+The GitHub Actions workflow checks out the [`rust-lang/this-week-in-rust`](https://github.com/rust-lang/this-week-in-rust) repository and detects the newest Markdown file in its `content` directory. If a new issue is found, it is parsed with the Rust application in `src/main.rs`, and the generated message is posted to the configured Telegram chat. Messages longer than Telegram's limit are split into several posts automatically.
 
 To run the workflow locally you must clone the `this-week-in-rust` repository into a `twir` subdirectory:
 


### PR DESCRIPTION
## Summary
- split generated summaries into chunks no longer than 4000 characters
- adjust workflow to send every chunk as a separate Telegram message
- document multi-post behaviour in README

## Testing
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*
- `cargo build` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685d2302569883328a9e66cf886de718