### PR TITLE
Add HTML link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository contains a small tool and workflow for sending summaries of the latest **This Week in Rust** post to Telegram.
 
 The GitHub Actions workflow checks out the [`rust-lang/this-week-in-rust`](https://github.com/rust-lang/this-week-in-rust) repository and detects the newest Markdown file in its `content` directory. If a new issue is found, it is parsed with the Rust application in `src/main.rs`, and the generated message is posted to the configured Telegram chat. Messages longer than Telegram's limit are split into several posts automatically.
+The parser now also reads the `URL` field from the Markdown front matter and appends a link to the HTML version at the end of each Telegram message.
 
 To run the workflow locally you must clone the `this-week-in-rust` repository into a `twir` subdirectory:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ fn main() -> std::io::Result<()> {
     let title_re = Regex::new(r"(?m)^Title: (.+)$").unwrap();
     let number_re = Regex::new(r"(?m)^Number: (.+)$").unwrap();
     let date_re = Regex::new(r"(?m)^Date: (.+)$").unwrap();
+    let url_re = Regex::new(r"(?mi)^URL: (.+)$").unwrap();
 
     if let Some(title) = title_re.captures(&input).and_then(|c| c.get(1)) {
         output.push_str(&format!("**{}**", title.as_str()));
@@ -53,6 +54,11 @@ fn main() -> std::io::Result<()> {
     if let Some(date) = date_re.captures(&input).and_then(|c| c.get(1)) {
         output.push_str(&format!(" — {}\n\n---\n\n", date.as_str()));
     }
+
+    let url = url_re
+        .captures(&input)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().trim().to_string());
 
     // Разделы и ссылки
     let section_re = Regex::new(r"^##+\s+(.+)$").unwrap();
@@ -84,7 +90,9 @@ fn main() -> std::io::Result<()> {
 
     // Итог
     output.push_str("\n---\n\n");
-    output.push_str("_Полный выпуск: ссылка_\n");
+    if let Some(link) = url {
+        output.push_str(&format!("_Полный выпуск: [{0}]({0})_\n", link));
+    }
 
     let posts = split_posts(&output, TELEGRAM_LIMIT);
 


### PR DESCRIPTION
## Summary
- detect `URL` field in the Markdown front matter
- include this HTML link at the end of the Telegram message
- mention link extraction in the README

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685d3c9b448c83328be8760739c04637