### PR TITLE
Добавлен экранирующий Markdown и режим MarkdownV2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
               curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
                 -d "chat_id=${TELEGRAM_CHAT_ID}" \
                 --data-urlencode "text=$text" \
-                -d "parse_mode=Markdown"
+                -d "parse_mode=MarkdownV2"
             done
             echo "$latest_post" > last_sent.txt
           git config user.name github-actions

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,21 @@ use std::{env, fs};
 
 const TELEGRAM_LIMIT: usize = 4000;
 
+/// Escape characters that have special meaning in Telegram MarkdownV2.
+fn escape_markdown(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '_' | '*' | '[' | ']' | '(' | ')' => {
+                escaped.push('\\');
+                escaped.push(ch);
+            }
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
 fn split_posts(text: &str, limit: usize) -> Vec<String> {
     let mut posts = Vec::new();
     let mut current = String::new();
@@ -45,13 +60,13 @@ fn main() -> std::io::Result<()> {
     let date_re = Regex::new(r"(?m)^Date: (.+)$").unwrap();
 
     if let Some(title) = title_re.captures(&input).and_then(|c| c.get(1)) {
-        output.push_str(&format!("**{}**", title.as_str()));
+        output.push_str(&format!("**{}**", escape_markdown(title.as_str())));
     }
     if let Some(number) = number_re.captures(&input).and_then(|c| c.get(1)) {
-        output.push_str(&format!(" — #{}", number.as_str()));
+        output.push_str(&format!(" — #{}", escape_markdown(number.as_str())));
     }
     if let Some(date) = date_re.captures(&input).and_then(|c| c.get(1)) {
-        output.push_str(&format!(" — {}\n\n---\n\n", date.as_str()));
+        output.push_str(&format!(" — {}\n\n---\n\n", escape_markdown(date.as_str())));
     }
 
     // Разделы и ссылки
@@ -73,7 +88,7 @@ fn main() -> std::io::Result<()> {
                     first_section = false;
                 }
                 if let Some(title) = current_section.take() {
-                    output.push_str(&format!("**{}**\n", title));
+                    output.push_str(&format!("**{}**\n", escape_markdown(&title)));
                     for link in &section_links {
                         output.push_str(link);
                         output.push('\n');
@@ -88,7 +103,11 @@ fn main() -> std::io::Result<()> {
         if let Some(caps) = link_re.captures(line) {
             let title = &caps[1];
             let url = &caps[2];
-            section_links.push(format!("- [{}]({})", title, url));
+            section_links.push(format!(
+                "- [{}]({})",
+                escape_markdown(title),
+                escape_markdown(url)
+            ));
         }
     }
 
@@ -97,7 +116,7 @@ fn main() -> std::io::Result<()> {
             output.push('\n');
         }
         if let Some(title) = current_section.take() {
-            output.push_str(&format!("**{}**\n", title));
+            output.push_str(&format!("**{}**\n", escape_markdown(&title)));
             for link in &section_links {
                 output.push_str(link);
                 output.push('\n');


### PR DESCRIPTION
## Изменения
- реализована функция `escape_markdown` для экранирования специальных символов Markdown
- все вставляемые из входных данных строки теперь проходят через эту функцию
- в `deploy.yml` режим парсинга изменён на `MarkdownV2`

## Тестирование
- `cargo build` *(ошибка из-за отсутствия доступа к crates.io)*
- `cargo test` *(ошибка из-за отсутствия доступа к crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_685d41b8cbd883329c898169b1dbf3ba