### PR TITLE
Добавление нумерации частей

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -110,10 +110,13 @@ fn main() -> std::io::Result<()> {
     output.push_str("_Полный выпуск: ссылка_\n");
 
     let posts = split_posts(&output, TELEGRAM_LIMIT);
+    let total = posts.len();
 
+    // Add part number prefix to each fragment
     for (i, post) in posts.iter().enumerate() {
+        let numbered = format!("*Часть {}/{}*\n{}", i + 1, total, post);
         let file_name = format!("output_{}.md", i + 1);
-        fs::write(&file_name, post)?;
+        fs::write(&file_name, numbered)?;
         println!("Generated {}", file_name);
     }
 


### PR DESCRIPTION
## Summary
- add prefix with part numbers when splitting posts

## Testing
- `cargo check` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_685d41b59bfc8332963d53ffc22b96ba