### PR TITLE
Implement Crate of the Week parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> std::io::Result<()> {
     let input = fs::read_to_string(input_path)?;
     let mut output = String::new();
 
-    // Заголовок и дата
+    // Title and date
     let title_re = Regex::new(r"(?m)^Title: (.+)$").unwrap();
     let number_re = Regex::new(r"(?m)^Number: (.+)$").unwrap();
     let date_re = Regex::new(r"(?m)^Date: (.+)$").unwrap();
@@ -54,12 +54,13 @@ fn main() -> std::io::Result<()> {
         output.push_str(&format!(" — {}\n\n---\n\n", date.as_str()));
     }
 
-    // Разделы и ссылки
+    // Sections and links
     let section_re = Regex::new(r"^##+\s+(.+)$").unwrap();
     let link_re = Regex::new(r"^[*-] \[(.+?)\]\((.+?)\)").unwrap();
+    let cotw_re = Regex::new(r"^\[(.+?)\]\((.+?)\)\s*[—-]\s*(.+)$").unwrap();
 
     let mut lines = input.lines().peekable();
-    // Название текущего раздела и накопленные ссылки
+    // Current section name and collected links
     let mut current_section: Option<String> = None;
     let mut section_links: Vec<String> = Vec::new();
     let mut first_section = true;
@@ -81,7 +82,24 @@ fn main() -> std::io::Result<()> {
                 }
                 section_links.clear();
             }
-            current_section = Some(sec[1].trim().to_string());
+
+            let title = sec[1].trim();
+            if title == "Crate of the Week" {
+                if let Some(next_line) = lines.next() {
+                    if let Some(caps) = cotw_re.captures(next_line) {
+                        if !first_section {
+                            output.push('\n');
+                        } else {
+                            first_section = false;
+                        }
+                        output.push_str("**Crate of the Week**\n");
+                        output.push_str(&format!("- [{}]({}) — {}\n", &caps[1], &caps[2], &caps[3]));
+                    }
+                }
+                current_section = None;
+            } else {
+                current_section = Some(title.to_string());
+            }
             continue;
         }
 
@@ -105,7 +123,7 @@ fn main() -> std::io::Result<()> {
         }
     }
 
-    // Итог
+    // Summary
     output.push_str("\n---\n\n");
     output.push_str("_Полный выпуск: ссылка_\n");
 


### PR DESCRIPTION
## Summary
- parse the `Crate of the Week` section
- keep comments in English

## Testing
- `cargo build --offline` *(fails: no matching package named `regex` found)*
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d41b0dc2083329f9e7f83d53175cb