### PR TITLE
Fix bullet escaping and skip empty git commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,9 +48,11 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add last_sent.txt
-          git commit -m "Update last_sent.txt"
-          git pull --rebase
-          git push
+          if ! git diff --staged --quiet; then
+            git commit -m "Update last_sent.txt"
+            git pull --rebase
+            git push
+          fi
           else
             echo "No new release. Skipping Telegram notification."
           fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,8 +141,10 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
                             first_section = false;
                         }
                         output.push_str("**Crate of the Week**\n");
-                        output
-                            .push_str(&format!("- [{}]({}) — {}\n", &caps[1], &caps[2], &caps[3]));
+                        output.push_str(&format!(
+                            "\\- [{}]({}) — {}\n",
+                            &caps[1], &caps[2], &caps[3]
+                        ));
                     }
                 }
                 current_section = None;
@@ -156,7 +158,7 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
             let title = &caps[1];
             let url = &caps[2];
             section_links.push(format!(
-                "- [{}]({})",
+                "\\- [{}]({})",
                 escape_markdown(title),
                 escape_markdown(url)
             ));


### PR DESCRIPTION
## Summary
- escape `-` characters in Telegram messages
- avoid git commit when there are no changes

## Testing
- `cargo fmt --all`
- `cargo check` *(failed: failed to download from `https://index.crates.io/config.json`)*
- `cargo clippy -- -D warnings` *(failed: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685da914a88083329c6efaada51dd141