### PR TITLE
Fix Telegram dash escaping

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
         output.push_str(&format!(" — \\#{}", escape_markdown(n)));
     }
     if let Some(ref d) = date {
-        output.push_str(&format!(" — {}\n\n---\n\n", escape_markdown(d)));
+        output.push_str(&format!(" — {}\n\n\\-\\-\\-\n\n", escape_markdown(d)));
     }
 
     let url = if let (Some(ref d), Some(ref n)) = (date.as_ref(), number.as_ref()) {
@@ -180,7 +180,7 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
         }
     }
 
-    output.push_str("\n---\n\n");
+    output.push_str("\n\\-\\-\\-\n\n");
     if let Some(link) = url {
         output.push_str(&format!("_Полный выпуск: {}_\n", escape_markdown(&link)));
     }


### PR DESCRIPTION
## Summary
- escape dashes in separator lines so Telegram MarkdownV2 parses messages correctly

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `cargo clippy -- -D warnings` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6863c7437fa48332ad3dd3ff4d4e2d8b