### PR TITLE
Fix Telegram link escaping

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -200,10 +200,7 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
 
     output.push_str("\n\\-\\-\\-\n\n");
     if let Some(link) = url {
-        output.push_str(&format!(
-            "_Полный выпуск: {}_\n",
-            escape_markdown_url(&link)
-        ));
+        output.push_str(&format!("_Полный выпуск: {}_\n", escape_markdown(&link)));
     }
 
     let raw_posts = split_posts(&output, TELEGRAM_LIMIT);


### PR DESCRIPTION
## Summary
- escape hyphen and other MarkdownV2 characters in the final digest link

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json)*
- `cargo clippy -- -D warnings` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863d1d8d8d083328c1894ded75c0f8e