### PR TITLE
Fix escaping of final digest link

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,7 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
 
     output.push_str("\n\\-\\-\\-\n\n");
     if let Some(link) = url {
-        output.push_str(&format!("_Полный выпуск: {}_\n", escape_markdown(&link)));
+        output.push_str(&format!("_Полный выпуск: {}_\n", link));
     }
 
     let raw_posts = split_posts(&output, TELEGRAM_LIMIT);


### PR DESCRIPTION
## Summary
- stop escaping the 'full digest' link

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: failed to download index)*
- `cargo clippy -- -D warnings` *(fails: failed to download index)*

------
https://chatgpt.com/codex/tasks/task_e_6863e7d658788332b1987461d119bee5