### PR TITLE
Fix telegram markdown for digest link

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,8 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
 
     output.push_str("\n\\-\\-\\-\n\n");
     if let Some(link) = url {
-        output.push_str(&format!("_Полный выпуск: {}_\n", link));
+        // Italicize only the prefix so that the URL remains valid.
+        output.push_str(&format!("_Полный выпуск:_ {}\n", link));
     }
 
     let raw_posts = split_posts(&output, TELEGRAM_LIMIT);


### PR DESCRIPTION
## Summary
- avoid italicizing the full digest URL so Telegram no longer rejects the message

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `cargo clippy -- -D warnings` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6863eb7f69a08332a7c1d15ac3620c0a