### PR TITLE
Use teloxide for URL escaping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 regex = "1"
 pulldown-cmark = "0.9"
+teloxide = { version = "0.12", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use pulldown_cmark::{Event, HeadingLevel, Parser, Tag};
 use regex::Regex;
 use std::{env, fs, path::Path};
+use teloxide::utils::markdown as tl_m;
 
 /// Representation of a single TWIR section.
 #[derive(Default)]
@@ -40,6 +41,11 @@ pub fn escape_markdown_url(url: &str) -> String {
         }
     }
     escaped
+}
+
+/// Escape characters for MarkdownV2 URLs using `teloxide` utilities.
+pub fn escape_url(url: &str) -> String {
+    tl_m::escape_url(url)
 }
 
 /// Convert Markdown-formatted text into plain text with URLs in parentheses
@@ -205,7 +211,7 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
         let link_block = format!(
             "\n---\n\nПолный выпуск: [{}]({})",
             escape_markdown(&link),
-            escape_markdown_url(&link)
+            escape_url(&link)
         );
         if current.len() + link_block.len() > TELEGRAM_LIMIT && !current.is_empty() {
             posts.push(current.clone());


### PR DESCRIPTION
## Summary
- add teloxide as a dependency
- add `escape_url` helper using teloxide
- update code to use `escape_url`

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: failed to download crates)*
- `cargo clippy -- -D warnings` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6864f61adc5c833289d9a64790119b72