### PR TITLE
Add CI workflow and extra unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - run: cargo fmt --all -- --check
+      - run: cargo check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,4 +327,18 @@ mod tests {
         assert_eq!(secs[0].title, "Links");
         assert_eq!(secs[0].lines, vec!["- [Rust](https://rust-lang.org)"]);
     }
+
+    #[test]
+    fn escape_markdown_basic() {
+        let text = "_bold_ *italic*";
+        let escaped = escape_markdown(text);
+        assert_eq!(escaped, "\\_bold\\_ \\*italic\\*");
+    }
+
+    #[test]
+    fn escape_url_parentheses() {
+        let url = "https://example.com/path(1)";
+        let escaped = escape_url(url);
+        assert_eq!(escaped, "https://example.com/path\\(1\\)");
+    }
 }


### PR DESCRIPTION
## Summary
- test escaping helpers
- add GitHub Actions workflow to run `cargo` checks and tests

## Testing
- `cargo fmt --all`
- `cargo check` *(failed: failed to download from `https://index.crates.io/config.json`)*
- `cargo clippy -- -D warnings` *(failed: failed to download from `https://index.crates.io/config.json`)*
- `cargo test` *(failed: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6864fa753e6c83328ba91ba037c20e79