### PR TITLE
Remove unused teloxide import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use pulldown_cmark::{Event, HeadingLevel, Parser, Tag};
 use regex::Regex;
 use std::{env, fs, path::Path};
-use teloxide::utils::markdown as tl_m;
 
 /// Representation of a single TWIR section.
 #[derive(Default)]


### PR DESCRIPTION
## Summary
- clean up src/main.rs by removing unused teloxide import

## Testing
- `cargo fmt --all`
- `cargo check` *(failed: failed to download from `https://index.crates.io/config.json`)*
- `cargo clippy -- -D warnings` *(failed: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68654c9221d8833288d611833f779634