### PR TITLE
Use artifact for last sent tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,15 @@ jobs:
         with:
           persist-credentials: true
 
+      - name: Download last_sent artifact from previous run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prev=$(gh run list -w "${{ github.workflow }}" -L 2 --json databaseId -q '.[1].databaseId' || echo "")
+          if [ -n "$prev" ]; then
+            gh run download "$prev" -n last-sent || true
+          fi
+
       - name: Checkout TWIR
         uses: actions/checkout@v4
         with:
@@ -45,14 +54,13 @@ jobs:
                 -d "parse_mode=MarkdownV2"
             done
             echo "$latest_post" > last_sent.txt
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add last_sent.txt
-          if ! git diff --staged --quiet; then
-            git commit -m "Update last_sent.txt"
-            git pull --rebase
-            git push
-          fi
           else
             echo "No new release. Skipping Telegram notification."
           fi
+
+      - name: Upload last_sent artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: last-sent
+          path: last_sent.txt
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 output_*.md
 twir/
+
+last_sent.txt

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ After that you can run the tool manually with:
 cargo run -- twir/content/<file-name>.md
 ```
 
-The workflow keeps track of the last processed file in `last_sent.txt`.
+The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.

--- a/last_sent.txt
+++ b/last_sent.txt
@@ -1,1 +1,0 @@
-twir/content/2025-06-25-this-week-in-rust.md


### PR DESCRIPTION
## Summary
- ignore `last_sent.txt` and remove from repo
- track last sent issue in GitHub Actions artifact instead of git
- update docs about new artifact workflow

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: failed to download from `https://index.crates.io`)*
- `cargo clippy -- -D warnings` *(fails: failed to download from `https://index.crates.io`)*
- `cargo test` *(fails: failed to download from `https://index.crates.io`)*

------
https://chatgpt.com/codex/tasks/task_e_6864fb2c948c8332b0f1c1b58a705333