### PR TITLE
ci: send summary on manual trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n1)
           last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$latest_post" != "$last_sent" ]; then
+          if [ "$GITHUB_EVENT_NAME" != "schedule" ] || [ "$latest_post" != "$last_sent" ]; then
             rm -f output_*.md
             cargo run -- "$latest_post"
             for file in $(ls -v output_*.md 2>/dev/null); do

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,3 +10,6 @@
 
 ## 2025-07-02
 - Expanded unit tests and continuous integration workflow.
+
+## 2025-07-03
+- Updated deploy workflow to skip previous version checks when the run is not triggered by the scheduler.


### PR DESCRIPTION
## Summary
- allow deploy workflow to send summary whenever the run isn't schedule-triggered
- document change in DEVLOG

## Testing
- `cargo fmt --all`
- `cargo check` *(failed: failed to download crates)*
- `cargo clippy -- -D warnings` *(failed: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6865701ecc848332ac365f8a4a8aa208