### PR TITLE
Fix markdown escaping

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn parse_sections(text: &str) -> Vec<Section> {
                 if let Some(ref mut sec) = current {
                     let line = buffer.trim();
                     if !line.is_empty() {
-                        sec.lines.push(format!("- {}", line));
+                        sec.lines.push(format!("\\- {}", line));
                     }
                 }
                 buffer.clear();
@@ -130,7 +130,7 @@ fn parse_sections(text: &str) -> Vec<Section> {
                     buffer.push(')');
                 }
             }
-            Event::Text(t) | Event::Code(t) => buffer.push_str(&t),
+            Event::Text(t) | Event::Code(t) => buffer.push_str(&escape_markdown(&t)),
             Event::SoftBreak | Event::HardBreak => buffer.push(' '),
             _ => {}
         }
@@ -324,7 +324,7 @@ mod tests {
         let secs = parse_sections(text);
         assert_eq!(secs.len(), 1);
         assert_eq!(secs[0].title, "Links");
-        assert_eq!(secs[0].lines, vec!["- [Rust](https://rust-lang.org)"]);
+        assert_eq!(secs[0].lines, vec!["\\- [Rust](https://rust-lang.org)"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- escape markdown in list item text and code events
- ensure list items start with an escaped dash
- adjust unit test expectations accordingly

## Testing
- `cargo fmt --all`
- `cargo check` *(failed: failed to download config.json)*
- `cargo clippy -- -D warnings` *(failed: failed to download config.json)*
- `cargo test` *(failed: failed to download config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68657c4548808332956494a53febd7e9