### PR TITLE
Handle Telegram API response

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,10 +48,15 @@ jobs:
             cargo run -- "$latest_post"
             for file in $(ls -v output_*.md 2>/dev/null); do
               text=$(cat "$file")
-              curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+              resp=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
                 -d "chat_id=${TELEGRAM_CHAT_ID}" \
                 --data-urlencode "text=$text" \
-                -d "parse_mode=MarkdownV2"
+                -d "parse_mode=MarkdownV2")
+              ok=$(echo "$resp" | jq -r '.ok')
+              if [ "$ok" != "true" ]; then
+                echo "Telegram API error: $resp"
+                exit 1
+              fi
             done
             echo "$latest_post" > last_sent.txt
           else

--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ cargo run -- twir/content/<file-name>.md
 ```
 
 The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.
+
+The Telegram API response is checked with `jq`, and the workflow fails if the server does not return `{ "ok": true }`.


### PR DESCRIPTION
## Summary
- check Telegram API response in `deploy.yml`
- mention API response validation in the README

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: failed to download crates)*
- `cargo clippy -- -D warnings` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68657c3fb9e08332bbd618d97bf0c68b