### PR TITLE
Fix Telegram link block

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,7 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
 
     if let Some(link) = url {
         let link_block = format!(
-            "\n---\n\nПолный выпуск: [{}]({})",
+            "\n\\-\\-\\-\n\nПолный выпуск: [{}]({})",
             escape_markdown(&link),
             escape_url(&link)
         );


### PR DESCRIPTION
## Summary
- escape hyphens in the link block separator for Telegram

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: network access blocked)*
- `cargo clippy -- -D warnings` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68658892e188833285e3255e15eb5add