### PR TITLE
Update AGENTS guidelines and fix clippy issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 - Responses may be in Russian or English as appropriate.
 - All code comments and technical documentation must be written in English.
-- After making any changes, run `cargo fmt --all`, `cargo check`, and `cargo clippy -- -D warnings`.
+- Install required Rust components with `rustup component add clippy rustfmt`.
+- After making any changes, run `cargo fmt --all`, `cargo check --all-targets --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`.
 - Fix every issue reported by these commands before committing or submitting pull requests.
+- A pull request is complete only when formatting, linting, `cargo check`, and tests all succeed.
 - Always review `DEVLOG.md` and `ARCHITECTURE.md` before making any modifications.

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,17 +105,16 @@ fn parse_sections(text: &str) -> Vec<Section> {
     let mut sections = Vec::new();
     let mut current: Option<Section> = None;
     let mut buffer = String::new();
-    let mut parser = Parser::new(text).into_iter().peekable();
     let mut link_dest: Option<String> = None;
-    while let Some(event) = parser.next() {
+    for event in Parser::new(text) {
         match event {
-            Event::Start(Tag::Heading(level, ..)) if level == HeadingLevel::H2 => {
+            Event::Start(Tag::Heading(HeadingLevel::H2, ..)) => {
                 if let Some(sec) = current.take() {
                     sections.push(sec);
                 }
                 buffer.clear();
             }
-            Event::End(Tag::Heading(level, ..)) if level == HeadingLevel::H2 => {
+            Event::End(Tag::Heading(HeadingLevel::H2, ..)) => {
                 current = Some(Section {
                     title: buffer.trim().to_string(),
                     lines: Vec::new(),
@@ -183,7 +182,7 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
         .and_then(|c| c.get(1))
         .map(|m| m.as_str().trim().to_string());
 
-    let url = if let (Some(ref d), Some(ref n)) = (date.as_ref(), number.as_ref()) {
+    let url = if let (Some(d), Some(n)) = (date.as_ref(), number.as_ref()) {
         let parts: Vec<&str> = d.split('-').collect();
         if parts.len() >= 3 {
             Some(format!(


### PR DESCRIPTION
## Summary
- document new install/check/test steps in AGENTS.md
- address clippy lints in `parse_sections` and URL logic

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68659c273ac083328a25c62fde45e668