### PR TITLE
Fix clippy errors and newline handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn fix_bare_link(line: &str) -> String {
     if let Some(caps) = re.captures(line) {
         let url = caps.get(1).unwrap().as_str();
         let text = line[..caps.get(0).unwrap().start()].trim_end();
-        format!("[{}]({})", text, url)
+        format!("[{text}]({url})")
     } else {
         line.to_string()
     }
@@ -147,7 +147,7 @@ fn parse_sections(text: &str) -> Vec<Section> {
                     if !line.is_empty() {
                         let fixed = fix_bare_link(line);
                         let indent = "  ".repeat(list_depth.saturating_sub(1));
-                        sec.lines.push(format!("{}• {}", indent, fixed));
+                        sec.lines.push(format!("{indent}• {fixed}"));
                         buffer.clear();
                     }
                 }
@@ -165,7 +165,7 @@ fn parse_sections(text: &str) -> Vec<Section> {
                     if !line.is_empty() {
                         let fixed = fix_bare_link(line);
                         let indent = "  ".repeat(list_depth.saturating_sub(1));
-                        sec.lines.push(format!("{}• {}", indent, fixed));
+                        sec.lines.push(format!("{indent}• {fixed}"));
                     }
                 }
                 buffer.clear();
@@ -202,7 +202,7 @@ fn parse_sections(text: &str) -> Vec<Section> {
                         let mut line = String::from("|");
                         for (i, cell) in r.into_iter().enumerate() {
                             let width = widths[i];
-                            line.push_str(&format!(" {:width$} |", cell, width = width));
+                            line.push_str(&format!(" {cell:width$} |"));
                         }
                         sec.lines.push(line);
                     }
@@ -367,7 +367,12 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
     posts
         .into_iter()
         .enumerate()
-        .map(|(i, post)| format!("*Часть {}/{}*\n{}", i + 1, total, post))
+        .map(|(i, mut post)| {
+            if !post.ends_with('\n') {
+                post.push('\n');
+            }
+            format!("*Часть {}/{}*\n{}", i + 1, total, post)
+        })
         .collect()
 }
 
@@ -496,7 +501,7 @@ mod tests {
         assert_eq!(secs.len(), 1);
         assert_eq!(secs[0].title, "Test");
         assert_eq!(secs[0].lines, vec!["> quoted text\n```\ncode line\n```"]);
-        let posts = generate_posts(format!("Title: T\nNumber: 1\nDate: 2025-01-01\n\n{}", text));
+        let posts = generate_posts(format!("Title: T\nNumber: 1\nDate: 2025-01-01\n\n{text}"));
         let combined = posts.join("\n");
         assert!(combined.contains("> quoted text"));
         assert!(combined.contains("```\ncode line\n```"));


### PR DESCRIPTION
## Summary
- fix `clippy::uninlined_format_args` warnings
- ensure generated posts end with a newline

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68663537abb083329b6c944df51a76cf