### PR TITLE
Improve subheading formatting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,11 @@ pub fn format_heading(title: &str) -> String {
     format!("📰 **{}**", escape_markdown(&upper))
 }
 
+/// Format a subheading without emoji
+pub fn format_subheading(title: &str) -> String {
+    format!("**{}**", escape_markdown(title))
+}
+
 /// Convert Markdown-formatted text into plain text with URLs in parentheses
 pub fn markdown_to_plain(text: &str) -> String {
     let without_escapes = text.replace('\\', "");
@@ -119,6 +124,24 @@ fn parse_sections(text: &str) -> Vec<Section> {
                     title: buffer.trim().to_string(),
                     lines: Vec::new(),
                 });
+                buffer.clear();
+            }
+            Event::Start(Tag::Heading(HeadingLevel::H3 | HeadingLevel::H4, ..)) => {
+                if let Some(ref mut sec) = current {
+                    let line = buffer.trim_end();
+                    if !line.is_empty() {
+                        sec.lines.push(line.to_string());
+                    }
+                }
+                buffer.clear();
+            }
+            Event::End(Tag::Heading(HeadingLevel::H3 | HeadingLevel::H4, ..)) => {
+                if let Some(ref mut sec) = current {
+                    let heading = buffer.trim();
+                    if !heading.is_empty() {
+                        sec.lines.push(format_subheading(heading));
+                    }
+                }
                 buffer.clear();
             }
             Event::Start(Tag::List(_)) => {

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -4,15 +4,15 @@
 \-\-\-
 
 📰 **UPDATES FROM RUST COMMUNITY**
-• Official
+**Official**
 • [Announcing the Clippy feature freeze](https://blog.rust-lang.org/inside-rust/2025/06/21/announcing-the-clippy-feature-freeze/)
-• Newsletters
+**Newsletters**
 • [Rust Trends Issue \#67](https://rust-trends.com/newsletter/untangling-rust-errors-the-bzip2-rewrite/)
-• Project/Tooling Updates
+**Project/Tooling Updates**
 • [Tantivy 0\.24](https://quickwit.io/blog/tantivy-0.24)
 • [How to write Rust in the kernel: part 1](https://lwn.net/SubscriberLink/1024202/556fa7b3c51d7899/)
 • [GlueSQL v0\.17\.0 \- Added redb storage support](https://github.com/gluesql/gluesql/releases/tag/v0.17.0)
-• Observations/Thoughts
+**Observations/Thoughts**
 • [The Unreasonable Effectiveness of Fuzzing for Porting Programs](https://rjp.io/blog/2025-06-17-unreasonable-effectiveness-of-fuzzing)
 • [So you want to serialize some DER?](https://alexgaynor.net/2025/jun/20/serialize-some-der/)
 • [Why I Switched from Flutter \+ Rust to Rust \+ egui](https://jdiaz97.github.io/greenblog/posts/flutter_to_egui/)
@@ -23,7 +23,7 @@
 • [Defending Democracies With Rust](https://filtra.io/rust/interviews/helsing-jun-25)
 • [Rust: A language that grows with you, your career and your projects](https://kerkour.com/rust-grows-with-you)
 • \[video playlist\] [Scientific Computing in Rust 2025](https://www.youtube.com/watch?v=XyXMKuclTcQ&list=PLrueqeouhcZNRW7H26DfscFjGSf0Pzd8c)
-• Rust Walkthroughs
+**Rust Walkthroughs**
 • [Porting GPU shaders to Rust 30x faster with AI](https://rust-gpu.github.io/blog/2025/06/24/vulkan-shader-port/)
 • [Bitwise DNA Compression in Rust: Small Footprint with Fast Reverse Complements](https://arianfarid.me/articles/dna-compression.html)
 • [Writing a basic Linux device driver when you know nothing about Linux drivers or USB](https://crescentro.se/posts/writing-drivers/)
@@ -35,3 +35,7 @@
 📰 **CALLS FOR TESTING**
 • An important step for RFC implementation is for people to experiment with the implementation and give feedback, especially before stabilization\.If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 • No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.
+[Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list\.
+**\[RFCs\]\(https://github\.com/rust\-lang/rfcs/issues?q\=label%3Acall\-for\-testing\)**
+**\[Rust\]\(https://github\.com/rust\-lang/rust/labels/call\-for\-testing\)**
+**\[Rustup\]\(https://github\.com/rust\-lang/rustup/labels/call\-for\-testing\)**

--- a/tests/expected/expected2.md
+++ b/tests/expected/expected2.md
@@ -1,7 +1,10 @@
 *Часть 2/5*
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS**
-• CFP \- ProjectsAlways wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!Some of these tasks may also have mentors available, visit the task page for more information\.
+**CFP \\- Projects**
+• Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!Some of these tasks may also have mentors available, visit the task page for more information\.
 • [Continuwuity \- Default room ACLs](https://forgejo.ellis.link/continuwuation/continuwuity/issues/775)
 • [Continuwuity \- Ability to entirely disable typing and read receipts](https://forgejo.ellis.link/continuwuation/continuwuity/issues/821)
 • [Continuwuity \- bug: appservice users are not created on registration](https://forgejo.ellis.link/continuwuation/continuwuity/issues/813)
 • [Continuwuity \- Invite filtering / disable invites per account](https://forgejo.ellis.link/continuwuation/continuwuity/issues/836)
+If you are a Rust project owner and are looking for contributors, please submit tasks [here](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines) or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
+**CFP \\- Events**

--- a/tests/expected/expected3.md
+++ b/tests/expected/expected3.md
@@ -1,11 +1,12 @@
 *Часть 3/5*
 📰 **UPDATES FROM THE RUST PROJECT**
-• 448 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-17..2025-06-24)Compiler
+448 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-17..2025-06-24)
+**Compiler**
 • [perf: Cache the canonical instantiation of param\-envs](https://github.com/rust-lang/rust/pull/142316)
 • [asyncDrop trait without sync Drop generates an error](https://github.com/rust-lang/rust/pull/142606)
 • [stabilize generic\_arg\_infer](https://github.com/rust-lang/rust/pull/141610)
 • [skip no\-op drop glue](https://github.com/rust-lang/rust/pull/142508)
-• Library
+**Library**
 • [add trim\_prefix and trim\_suffix methods for both slice and str types](https://github.com/rust-lang/rust/pull/142331)
 • [allow comparisons between CStr, CString, and Cow<CStr\>](https://github.com/rust-lang/rust/pull/137268)
 • [allow storing format\_args\!\(\) in variable](https://github.com/rust-lang/rust/pull/140748)
@@ -14,15 +15,15 @@
 • [let String pass \#\[track\_caller\] to its Vec calls](https://github.com/rust-lang/rust/pull/142728)
 • [safer implementation of RepeatN](https://github.com/rust-lang/rust/pull/130887)
 • [use a distinct ToString implementation for u128 and i128](https://github.com/rust-lang/rust/pull/142294)
-• Cargo
+**Cargo**
 • [cargo: feat\(toml\): Parse support for multiple build scripts](https://github.com/rust-lang/cargo/pull/15630)
 • [cargo: feat: introduce perma unstable \-\-compile\-time\-deps option for cargo build](https://github.com/rust-lang/cargo/pull/15674)
 • [cargo: fix potential deadlock in CacheState::lock](https://github.com/rust-lang/cargo/pull/15698)
-• Rustdoc
+**Rustdoc**
 • [avoid a few more allocations in write\_shared\.rs](https://github.com/rust-lang/rust/pull/142667)
 • [rustdoc\-json: keep empty generic args if parenthesized](https://github.com/rust-lang/rust/pull/142932)
 • [rustdoc: make srcIndex no longer a global variable](https://github.com/rust-lang/rust/pull/142100)
-• Clippy
+**Clippy**
 • [use jemalloc for Clippy](https://github.com/rust-lang/rust/pull/142286)
 • [perf: Don't spawn so many compilers \(3/2\) \(19m → 250k\)](https://github.com/rust-lang/rust-clippy/pull/15030)
 • [Sugg: do not parenthesize a double unary operator](https://github.com/rust-lang/rust-clippy/pull/14983)
@@ -39,7 +40,7 @@
 • [fix false positive of borrow\_deref\_ref](https://github.com/rust-lang/rust-clippy/pull/14967)
 • [fix suggestion\-causes\-error of empty\_line\_after\_outer\_attr](https://github.com/rust-lang/rust-clippy/pull/15078)
 • [new lint: manual\_is\_multiple\_of](https://github.com/rust-lang/rust-clippy/pull/14292)
-• Rust\-Analyzer
+**Rust\\-Analyzer**
 • [rust\-analyzer: add fn parent\(self, db\) → GenericDef to hir::TypeParam](https://github.com/rust-lang/rust-analyzer/pull/20046)
 • [rust\-analyzer: cleanup folding\_ranges and support more things](https://github.com/rust-lang/rust-analyzer/pull/20080)
 • [rust\-analyzer: do not default to 'static for trait object lifetimes](https://github.com/rust-lang/rust-analyzer/pull/20036)
@@ -51,21 +52,28 @@
 • [rust\-analyzer: use ROOT hygiene for args inside new format\_args\! expansion](https://github.com/rust-lang/rust-analyzer/pull/20073)
 • [rust\-analyzer: hide imported privates if private editable is disabled](https://github.com/rust-lang/rust-analyzer/pull/20025)
 • [rust\-analyzer: mimic rustc's new format\_args\! expansion](https://github.com/rust-lang/rust-analyzer/pull/20056)
-Rust Compiler Performance TriageA week dominated by the landing of a large patch implementing [RFC\#3729](https://github.com/rust-lang/rfcs/pull/3729) which unfortunately introduced rather sizeable performance regressions \(avg of \~1% instruction count on 111 primary benchmarks\)\. This was deemed worth it so that the patch could land and performance could be won back in follow up PRs\.Triage done by @rylev\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)Summary:
+**Rust Compiler Performance Triage**
+A week dominated by the landing of a large patch implementing [RFC\#3729](https://github.com/rust-lang/rfcs/pull/3729) which unfortunately introduced rather sizeable performance regressions \(avg of \~1% instruction count on 111 primary benchmarks\)\. This was deemed worth it so that the patch could land and performance could be won back in follow up PRs\.Triage done by @rylev\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)Summary:
 | \(instructions:u\)              | mean    | range                 | count |
 | Regressions ❌  \(primary\)      | 1\.1%   | \[0\.2%, 9\.1%\]      | 123   |
 | Regressions ❌  \(secondary\)    | 1\.0%   | \[0\.1%, 4\.6%\]      | 86    |
 | Improvements ✅  \(primary\)     | \-3\.8% | \[\-7\.3%, \-0\.3%\]  | 2     |
 | Improvements ✅  \(secondary\)   | \-2\.3% | \[\-18\.5%, \-0\.2%\] | 44    |
 | All ❌✅ \(primary\)              | 1\.0%   | \[\-7\.3%, 9\.1%\]    | 125   |
-• 2 Regressions, 4 Improvements, 10 Mixed; 7 of them in rollups 40 artifact comparisons made in total[Full report here](https://github.com/rust-lang/rustc-perf/blob/a63db4d1799853b334e4106d914fba24e49c8782/triage/2025/2025-06-24.md)[Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
+2 Regressions, 4 Improvements, 10 Mixed; 7 of them in rollups 40 artifact comparisons made in total[Full report here](https://github.com/rust-lang/rustc-perf/blob/a63db4d1799853b334e4106d914fba24e49c8782/triage/2025/2025-06-24.md)
+**\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**
+• Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
 • No RFCs were approved this week\.
-• Final Comment PeriodEvery week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs which are reaching a decision\. Express your opinions now\.Tracking Issues & PRs[Rust](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
+**Final Comment Period**
+Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs which are reaching a decision\. Express your opinions now\.
+**Tracking Issues & PRs**
+• [Rust](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
 • [Use lld by default on x86\_64\-unknown\-linux\-gnu stable](https://github.com/rust-lang/rust/pull/140525)
 • [Allow \#\[must\_use\] on associated types to warn on unused values in generic contexts](https://github.com/rust-lang/rust/pull/142590)
 • [Fix proc\_macro::Ident 's handling of $crate](https://github.com/rust-lang/rust/pull/141996)
 • [Ensure non\-empty buffers for large vectored I/O](https://github.com/rust-lang/rust/pull/138879)
 • [Rust RFCs](https://github.com/rust-lang/rfcs/labels/final-comment-period)
 • [RFC: \-\-crate\-attr](https://github.com/rust-lang/rfcs/pull/3791)
-• No Items entered Final Comment Period this week for [Cargo](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.[New and Updated RFCs](https://github.com/rust-lang/rfcs/pulls)
+No Items entered Final Comment Period this week for [Cargo](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.
+**\[New and Updated RFCs\]\(https://github\.com/rust\-lang/rfcs/pulls\)**
 • No New or Updated RFCs were created this week\.

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -1,6 +1,7 @@
 *Часть 4/5*
 📰 **UPCOMING EVENTS**
-• Rusty Events between 2025\-06\-25 \- 2025\-07\-23 🦀Virtual
+Rusty Events between 2025\-06\-25 \- 2025\-07\-23 🦀
+**Virtual**
 • 2025\-06\-25 \| Virtual \(Lima, PE\)\| [Perú Rust User Group](https://www.meetup.com/peru-rust-user-group/)
   • [Interfaces y Costos en la nube con Rust](https://www.meetup.com/peru-rust-user-group/events/308543965/)
 • 2025\-06\-26 \| Virtual \(Girona, ES\) \| [Rust Girona](https://lu.ma/rust-girona)
@@ -37,12 +38,12 @@
   • [Fourth Tuesday](https://www.meetup.com/dallasrust/events/tgctrtyhckbdc)
 • 2025\-07\-22 \| Virtual \(London, GB\) \| [Women in Rust](https://www.meetup.com/women-in-rust/events/)
   • [Lunch & Learn: Crates, Tips & Tricks Lightning Talks \- Bring your ideas\!](https://www.meetup.com/women-in-rust/events/307560304)
-• Asia
+**Asia**
 • 2025\-06\-28 \| Bangalore/Bengaluru, IN \| [Rust Bangalore](https://hasgeek.com/rustbangalore)
   • [June 2025 Rustacean meetup](https://hasgeek.com/rustbangalore/june-2025-rustacean-meetup/)
 • 2025\-07\-02 \| Seoul, KR \| [Seoul Rust \(Programming Language\) Meetup](https://www.meetup.com/rust-seoul-meetup/events/)
   • [Seoul Rust Meetup](https://www.meetup.com/rust-seoul-meetup/events/308408246)
-• Europe
+**Europe**
 • 2025\-06\-25 \| London, UK \| [London Rust Project Group](https://www.meetup.com/london-rust-project-group)
   • [Lessons learnt from making a tiny game in nostd Rust](https://www.meetup.com/london-rust-project-group/events/306809962)
 • 2025\-06\-25 \| Paris, FR \| [Systematic Paris Region](https://systematic-paris-region.org/)
@@ -79,7 +80,7 @@
   • [Topic TBD](https://www.meetup.com/rust-modern-systems-programming-in-leipzig/events/308592246)
 • 2025\-07\-15 \| London, UK \| [London Rust Project Group](https://www.meetup.com/london-rust-project-group/events/)
   • [TUI Power: Simulating & Visualising Sensor Data with Rust](https://www.meetup.com/london-rust-project-group/events/308434768)
-• North America
+**North America**
 • 2025\-06\-25 \| Austin, TX, US \| [Rust ATX](https://www.meetup.com/rust-atx)
   • [Rust Lunch \- Fareground](https://www.meetup.com/rust-atx/events/xvkdgtyhcjbhc)
 • 2025\-06\-26 \| Chicago, IL, US \| [Chicago Rust Meetup](https://www.meetup.com/chicago-rust-meetup/events/)
@@ -110,11 +111,11 @@
   • [July, 2025 Computer Programming Language Panel \(Special Event\)](https://www.meetup.com/seattle-rust-user-group/events/307698855)
 • 2025\-07\-23 \| Austin, TX, US \| [Rust ATX](https://www.meetup.com/rust-atx/events/)
   • [Rust Lunch \- Fareground](https://www.meetup.com/rust-atx/events/xvkdgtyhckbfc)
-• Oceania
+**Oceania**
 • 2025\-06\-30 \| Collingwood, VI, AU \| [Rust Melbourne](https://www.meetup.com/rust-melbourne/events/)
   • [June 2025 Mini Rust Melbourne Meetup](https://www.meetup.com/rust-melbourne/events/308546374)
 • 2025\-07\-01 \| Christchurch, NZ \| [Christchurch Rust Meetup Group](https://www.meetup.com/christchurch-rustlang-meetup-group/events/)
   • [July 2025 Christchurch Rust Meetup](https://www.meetup.com/christchurch-rustlang-meetup-group/events/308605782)
-• South America
+**South America**
 • 2025\-07\-12 \| São Paulo, BR \| [Rust São Paulo Meetup](https://www.meetup.com/rust-sao-paulo-meetup/events/)
   • [Encontro do Rust\-SP na WillBank](https://www.meetup.com/rust-sao-paulo-meetup/events/307308851)


### PR DESCRIPTION
## Summary
- add `format_subheading` for smaller headings
- treat H3/H4 Markdown headings as subheadings instead of list items
- update expected integration outputs

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686639a789f083328c25258fda3f5ee7