### PR TITLE
Отключить превью ссылок в Телеграме

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,8 @@ jobs:
               resp=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
                 -d "chat_id=${TELEGRAM_CHAT_ID}" \
                 --data-urlencode "text=$text" \
-                -d "parse_mode=MarkdownV2")
+                -d "parse_mode=MarkdownV2" \
+                -d "disable_web_page_preview=true")
               ok=$(echo "$resp" | jq -r '.ok')
               if [ "$ok" != "true" ]; then
                 echo "Telegram API error: $resp"


### PR DESCRIPTION
## Изменения
- добавлен параметр `disable_web_page_preview=true` в запрос отправки сообщений

## Тестирование
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686639f309288332ad39ad889cba68be