### PR TITLE
Add Markdown parsing guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,5 @@
   check whether `origin/main` contains new commits. Rebase your branch onto the
   latest `origin/main` if needed so all development starts from the most recent
   commit.
+- Read all Markdown (`*.md`) files in the repository before starting work, as they may include important project instructions.
+- Follow the guidelines in `PARSING.md`, especially the requirement to rely on crates for Markdown processing instead of custom parsing code.

--- a/PARSING.md
+++ b/PARSING.md
@@ -1,0 +1,5 @@
+# Markdown Parsing Guidelines
+
+- Always use established crates like `pulldown-cmark` for reading and parsing Markdown files.
+- Avoid implementing Markdown parsing logic manually unless absolutely necessary.
+- Review all Markdown files in the repository before starting new tasks, as they may contain important instructions or data for the project.


### PR DESCRIPTION
## Summary
- add PARSING.md with guidance to use crates for Markdown processing
- update AGENTS.md to direct reading Markdown files and following the new parsing guidelines

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68664cbaee008332a3e11b797edcb4ca