### PR TITLE
Fix paragraph handling in TWIR parser

### DIFF
--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -1,4 +1,4 @@
-*Часть 1/9*
+*Часть 1/10*
 **This Week in Rust 605** — \#605 — 2025\-06\-25
 
 \-\-\-
@@ -31,11 +31,6 @@
 • [The Complete Rust Security Handbook](https://yevh.github.io/rust-security-handbook/)
 
 📰 **CRATE OF THE WEEK**
-
-📰 **CALLS FOR TESTING**
-• An important step for RFC implementation is for people to experiment with the implementation and give feedback, especially before stabilization\.If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
-• No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.
-[Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list\.
-**\[RFCs\]\(https://github\.com/rust\-lang/rfcs/issues?q\=label%3Acall\-for\-testing\)**
-**\[Rust\]\(https://github\.com/rust\-lang/rust/labels/call\-for\-testing\)**
-**\[Rustup\]\(https://github\.com/rust\-lang/rustup/labels/call\-for\-testing\)**
+This week's crate is [primitive\_fixed\_point\_decimal](https://docs.rs/primitive_fixed_point_decimal), a crate of real fixed\-point decimal types\.
+Thanks to [Wu Bingzheng](https://users.rust-lang.org/t/crate-of-the-week/2704/1445) for the self\-suggestion\!
+[Please submit your suggestions and votes for next week](https://users.rust-lang.org/t/crate-of-the-week/2704)\!

--- a/tests/expected/expected10.md
+++ b/tests/expected/expected10.md
@@ -1,0 +1,15 @@
+*Часть 10/10*
+📰 **JOBS**
+Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1knkfb6/official_rrust_whos_hiring_thread_for_jobseekers/)
+Quote of the Week\> Our experience is that no matter how many safeguards you put on code, there’s no cure\-all that prevents bad programming\. Of course, to take the contrary argument, seat belts don’t stop all traffic fatalities, but you could just choose not to have accidents\. So we do have seat belts\. If Rust can prevent some mistakes or malicious intent, maybe it’s worth it even if it isn’t perfect\.
+
+– [Al Williams on hackaday](https://hackaday.com/2025/06/21/if-your-kernel-development-is-a-little-rusty/)
+Thanks to [Kill The Mule](https://users.rust-lang.org/t/twir-quote-of-the-week/328/1700) for the suggestion\!
+[Please submit quotes and vote for next week\!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)
+This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [U007D](https://github.com/U007D), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin), [bennyvasquez](https://github.com/bennyvasquez), [bdillo](https://github.com/bdillo)
+Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust-lang.org/)
+[Discuss on r/rust](https://www.reddit.com/r/rust/comments/1lknjc1/this_week_in_rust_605/)
+
+\-\-\-
+
+Полный выпуск: [https://this\-week\-in\-rust\.org/blog/2025/06/25/this\-week\-in\-rust\-605/](https://this-week-in-rust.org/blog/2025/06/25/this-week-in-rust-605/)

--- a/tests/expected/expected2.md
+++ b/tests/expected/expected2.md
@@ -1,10 +1,24 @@
-*Часть 2/9*
+*Часть 2/10*
+📰 **CALLS FOR TESTING**
+An important step for RFC implementation is for people to experiment with the implementation and give feedback, especially before stabilization\.
+If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
+• No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.
+[Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list\.
+**\[RFCs\]\(https://github\.com/rust\-lang/rfcs/issues?q\=label%3Acall\-for\-testing\)**
+**\[Rust\]\(https://github\.com/rust\-lang/rust/labels/call\-for\-testing\)**
+**\[Rustup\]\(https://github\.com/rust\-lang/rustup/labels/call\-for\-testing\)**
+If you are a feature implementer and would like your RFC to appear on the above list, add the new call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
+
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS**
 **CFP \\- Projects**
-• Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!Some of these tasks may also have mentors available, visit the task page for more information\.
+Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
+Some of these tasks may also have mentors available, visit the task page for more information\.
 • [Continuwuity \- Default room ACLs](https://forgejo.ellis.link/continuwuation/continuwuity/issues/775)
 • [Continuwuity \- Ability to entirely disable typing and read receipts](https://forgejo.ellis.link/continuwuation/continuwuity/issues/821)
 • [Continuwuity \- bug: appservice users are not created on registration](https://forgejo.ellis.link/continuwuation/continuwuity/issues/813)
 • [Continuwuity \- Invite filtering / disable invites per account](https://forgejo.ellis.link/continuwuation/continuwuity/issues/836)
 If you are a Rust project owner and are looking for contributors, please submit tasks [here](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines) or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
 **CFP \\- Events**
+Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker\.
+No Calls for papers or presentations were submitted this week\.
+If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!

--- a/tests/expected/expected3.md
+++ b/tests/expected/expected3.md
@@ -1,4 +1,4 @@
-*Часть 3/9*
+*Часть 3/10*
 📰 **UPDATES FROM THE RUST PROJECT**
 448 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-17..2025-06-24)
 **Compiler**

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -1,4 +1,4 @@
-*Часть 4/9*
+*Часть 4/10*
 • [rust\-analyzer: add fn parent\(self, db\) → GenericDef to hir::TypeParam](https://github.com/rust-lang/rust-analyzer/pull/20046)
 • [rust\-analyzer: cleanup folding\_ranges and support more things](https://github.com/rust-lang/rust-analyzer/pull/20080)
 • [rust\-analyzer: do not default to 'static for trait object lifetimes](https://github.com/rust-lang/rust-analyzer/pull/20036)
@@ -11,16 +11,19 @@
 • [rust\-analyzer: hide imported privates if private editable is disabled](https://github.com/rust-lang/rust-analyzer/pull/20025)
 • [rust\-analyzer: mimic rustc's new format\_args\! expansion](https://github.com/rust-lang/rust-analyzer/pull/20056)
 **Rust Compiler Performance Triage**
-A week dominated by the landing of a large patch implementing [RFC\#3729](https://github.com/rust-lang/rfcs/pull/3729) which unfortunately introduced rather sizeable performance regressions \(avg of \~1% instruction count on 111 primary benchmarks\)\. This was deemed worth it so that the patch could land and performance could be won back in follow up PRs\.Triage done by @rylev\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)Summary:
+A week dominated by the landing of a large patch implementing [RFC\#3729](https://github.com/rust-lang/rfcs/pull/3729) which unfortunately introduced rather sizeable performance regressions \(avg of \~1% instruction count on 111 primary benchmarks\)\. This was deemed worth it so that the patch could land and performance could be won back in follow up PRs\.
+Triage done by @rylev\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)
+Summary:
 | \(instructions:u\)              | mean    | range                 | count |
 | Regressions ❌  \(primary\)      | 1\.1%   | \[0\.2%, 9\.1%\]      | 123   |
 | Regressions ❌  \(secondary\)    | 1\.0%   | \[0\.1%, 4\.6%\]      | 86    |
 | Improvements ✅  \(primary\)     | \-3\.8% | \[\-7\.3%, \-0\.3%\]  | 2     |
 | Improvements ✅  \(secondary\)   | \-2\.3% | \[\-18\.5%, \-0\.2%\] | 44    |
 | All ❌✅ \(primary\)              | 1\.0%   | \[\-7\.3%, 9\.1%\]    | 125   |
-2 Regressions, 4 Improvements, 10 Mixed; 7 of them in rollups 40 artifact comparisons made in total[Full report here](https://github.com/rust-lang/rustc-perf/blob/a63db4d1799853b334e4106d914fba24e49c8782/triage/2025/2025-06-24.md)
+2 Regressions, 4 Improvements, 10 Mixed; 7 of them in rollups 40 artifact comparisons made in total
+[Full report here](https://github.com/rust-lang/rustc-perf/blob/a63db4d1799853b334e4106d914fba24e49c8782/triage/2025/2025-06-24.md)
 **\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**
-• Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
+Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
 • No RFCs were approved this week\.
 **Final Comment Period**
 Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs which are reaching a decision\. Express your opinions now\.

--- a/tests/expected/expected5.md
+++ b/tests/expected/expected5.md
@@ -1,5 +1,6 @@
-*Часть 5/9*
+*Часть 5/10*
 • [RFC: \-\-crate\-attr](https://github.com/rust-lang/rfcs/pull/3791)
-No Items entered Final Comment Period this week for [Cargo](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.
+No Items entered Final Comment Period this week for [Cargo](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.
+Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.
 **\[New and Updated RFCs\]\(https://github\.com/rust\-lang/rfcs/pulls\)**
 • No New or Updated RFCs were created this week\.

--- a/tests/expected/expected6.md
+++ b/tests/expected/expected6.md
@@ -1,4 +1,4 @@
-*Часть 6/9*
+*Часть 6/10*
 📰 **UPCOMING EVENTS**
 Rusty Events between 2025\-06\-25 \- 2025\-07\-23 🦀
 **Virtual**

--- a/tests/expected/expected7.md
+++ b/tests/expected/expected7.md
@@ -1,4 +1,4 @@
-*Часть 7/9*
+*Часть 7/10*
 • 2025\-07\-02 \| Seoul, KR \| [Seoul Rust \(Programming Language\) Meetup](https://www.meetup.com/rust-seoul-meetup/events/)
   • [Seoul Rust Meetup](https://www.meetup.com/rust-seoul-meetup/events/308408246)
 **Europe**

--- a/tests/expected/expected8.md
+++ b/tests/expected/expected8.md
@@ -1,4 +1,4 @@
-*Часть 8/9*
+*Часть 8/10*
 • 2025\-06\-25 \| Austin, TX, US \| [Rust ATX](https://www.meetup.com/rust-atx)
   • [Rust Lunch \- Fareground](https://www.meetup.com/rust-atx/events/xvkdgtyhcjbhc)
 • 2025\-06\-26 \| Chicago, IL, US \| [Chicago Rust Meetup](https://www.meetup.com/chicago-rust-meetup/events/)

--- a/tests/expected/expected9.md
+++ b/tests/expected/expected9.md
@@ -1,8 +1,2 @@
-*Часть 9/9*
-📰 **JOBS**
-Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1knkfb6/official_rrust_whos_hiring_thread_for_jobseekers/)Quote of the Week\> Our experience is that no matter how many safeguards you put on code, there’s no cure\-all that prevents bad programming\. Of course, to take the contrary argument, seat belts don’t stop all traffic fatalities, but you could just choose not to have accidents\. So we do have seat belts\. If Rust can prevent some mistakes or malicious intent, maybe it’s worth it even if it isn’t perfect\.
-– [Al Williams on hackaday](https://hackaday.com/2025/06/21/if-your-kernel-development-is-a-little-rusty/)Thanks to [Kill The Mule](https://users.rust-lang.org/t/twir-quote-of-the-week/328/1700) for the suggestion\![Please submit quotes and vote for next week\!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [U007D](https://github.com/U007D), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin), [bennyvasquez](https://github.com/bennyvasquez), [bdillo](https://github.com/bdillo)Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust-lang.org/)[Discuss on r/rust](https://www.reddit.com/r/rust/comments/1lknjc1/this_week_in_rust_605/)
-
-\-\-\-
-
-Полный выпуск: [https://this\-week\-in\-rust\.org/blog/2025/06/25/this\-week\-in\-rust\-605/](https://this-week-in-rust.org/blog/2025/06/25/this-week-in-rust-605/)
+*Часть 9/10*
+If you are running a Rust event please add it to the [calendar](https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com) to get it mentioned here\. Please remember to add a link to the event too\. Email the [Rust Community Team](mailto:community-team@rust-lang.org) for access\.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19,3 +19,23 @@ fn crate_of_the_week_is_preserved() {
     assert!(output.contains("📰 **CRATE OF THE WEEK**"));
     assert!(output.contains("primitive\\_fixed\\_point\\_decimal"));
 }
+
+#[test]
+fn crate_of_week_followed_by_section() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = "Title: Test\nNumber: 1\nDate: 2024-01-01\n\n## Crate of the Week\nThis week's crate is [demo](https://example.com).\n\n## Next\n- item\n";
+    let input_path = dir.path().join("input.md");
+    fs::write(&input_path, input).unwrap();
+
+    let status = Command::new(env!("CARGO_BIN_EXE_twir-deploy-notify"))
+        .arg(&input_path)
+        .current_dir(dir.path())
+        .status()
+        .expect("failed to run binary");
+    assert!(status.success());
+
+    let combined = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
+    assert!(combined.contains("📰 **CRATE OF THE WEEK**"));
+    assert!(combined.contains("[demo](https://example.com)"));
+    assert!(combined.contains("📰 **NEXT**"));
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19,6 +19,7 @@ fn parse_latest_issue_full() {
         include_str!("expected/expected7.md"),
         include_str!("expected/expected8.md"),
         include_str!("expected/expected9.md"),
+        include_str!("expected/expected10.md"),
     ];
 
     assert_eq!(posts.len(), expected.len(), "post count mismatch");


### PR DESCRIPTION
## Summary
- preserve paragraph content when parsing sections
- account for trailing text in last section
- test crate-of-week followed by a new section
- update integration expectations for new output

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686659e7d2248332ba552914b993a0cd