### PR TITLE
Add unicode width handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,15 +187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +231,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "convert_case"
@@ -488,7 +488,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -994,6 +994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,12 +1021,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "percent-encoding"
@@ -1702,9 +1702,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "twir-deploy-notify"
 version = "0.1.0"
 dependencies = [
- "once_cell",
- "mockito",
  "clap",
+ "mockito",
+ "once_cell",
  "proptest",
  "pulldown-cmark",
  "regex",
@@ -1713,6 +1713,7 @@ dependencies = [
  "serde_json",
  "teloxide",
  "tempfile",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1732,6 +1733,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ reqwest = { version = "0.11", default-features = false, features = ["blocking", 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
+unicode-width = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -14,12 +14,12 @@
 A week dominated by the landing of a large patch implementing [RFC\#3729](https://github.com/rust-lang/rfcs/pull/3729) which unfortunately introduced rather sizeable performance regressions \(avg of \~1% instruction count on 111 primary benchmarks\)\. This was deemed worth it so that the patch could land and performance could be won back in follow up PRs\.
 Triage done by @rylev\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)
 Summary:
-| \(instructions:u\)              | mean    | range                 | count |
-| Regressions ❌  \(primary\)      | 1\.1%   | \[0\.2%, 9\.1%\]      | 123   |
-| Regressions ❌  \(secondary\)    | 1\.0%   | \[0\.1%, 4\.6%\]      | 86    |
-| Improvements ✅  \(primary\)     | \-3\.8% | \[\-7\.3%, \-0\.3%\]  | 2     |
-| Improvements ✅  \(secondary\)   | \-2\.3% | \[\-18\.5%, \-0\.2%\] | 44    |
-| All ❌✅ \(primary\)              | 1\.0%   | \[\-7\.3%, 9\.1%\]    | 125   |
+| \(instructions:u\)             | mean    | range                 | count |
+| Regressions ❌  \(primary\)     | 1\.1%   | \[0\.2%, 9\.1%\]      | 123   |
+| Regressions ❌  \(secondary\)   | 1\.0%   | \[0\.1%, 4\.6%\]      | 86    |
+| Improvements ✅  \(primary\)    | \-3\.8% | \[\-7\.3%, \-0\.3%\]  | 2     |
+| Improvements ✅  \(secondary\)  | \-2\.3% | \[\-18\.5%, \-0\.2%\] | 44    |
+| All ❌✅ \(primary\)             | 1\.0%   | \[\-7\.3%, 9\.1%\]    | 125   |
 2 Regressions, 4 Improvements, 10 Mixed; 7 of them in rollups 40 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/a63db4d1799853b334e4106d914fba24e49c8782/triage/2025/2025-06-24.md)
 **\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**


### PR DESCRIPTION
## Summary
- include `unicode-width` crate
- compute table column widths using Unicode character width
- fix clippy warnings and update expected output

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6866781d43a08332a3c2c3049a94319c