### PR TITLE
Add documentation consistency check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
       - run: cargo check --all-targets --all-features
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test -- --test-threads=$(nproc)
+      - run: cargo run --bin check-docs
 
   coverage:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1896,7 @@ dependencies = [
  "serde_json",
  "teloxide",
  "tempfile",
+ "walkdir",
 ]
 
 [[package]]
@@ -1967,6 +1977,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2092,6 +2112,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"
+walkdir = "2"
 
 [dev-dependencies]
 tempfile = "3"
@@ -22,3 +23,7 @@ proptest = "1"
 
 [features]
 integration = []
+
+[[bin]]
+name = "check-docs"
+path = "src/bin/check_docs.rs"

--- a/src/bin/check_docs.rs
+++ b/src/bin/check_docs.rs
@@ -1,0 +1,82 @@
+use pulldown_cmark::{CodeBlockKind, Event, Parser, Tag};
+use regex::Regex;
+use std::{fs, path::Path};
+use walkdir::WalkDir;
+
+fn function_exists(name: &str) -> std::io::Result<bool> {
+    for entry in WalkDir::new("src").into_iter().chain(WalkDir::new("tests")) {
+        let entry = entry?;
+        if entry.path().extension().and_then(|e| e.to_str()) == Some("rs") {
+            let content = fs::read_to_string(entry.path())?;
+            if content.contains(&format!("fn {}", name)) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let file_re = Regex::new(r"^([A-Za-z0-9_./-]+\\.rs)$")?;
+    let func_re = Regex::new(r"^([A-Za-z0-9_]+)\\()$")?;
+
+    let mut missing = Vec::new();
+
+    for entry in WalkDir::new(".").into_iter().filter_map(Result::ok) {
+        if entry.path().extension().and_then(|e| e.to_str()) == Some("md") {
+            let content = fs::read_to_string(entry.path())?;
+            let parser = Parser::new(&content);
+            let mut in_block = false;
+            for event in parser {
+                match event {
+                    Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(_))) => in_block = true,
+                    Event::End(Tag::CodeBlock(_)) => in_block = false,
+                    Event::Code(code) | Event::Text(code) if in_block => {
+                        if let Some(cap) = file_re.captures(&code) {
+                            let p = cap.get(1).unwrap().as_str();
+                            if !Path::new(p).exists() {
+                                missing
+                                    .push(format!("{}: missing file {p}", entry.path().display()));
+                            }
+                        } else if let Some(cap) = func_re.captures(&code) {
+                            let name = cap.get(1).unwrap().as_str();
+                            if !function_exists(name)? {
+                                missing.push(format!(
+                                    "{}: missing function {name}",
+                                    entry.path().display()
+                                ));
+                            }
+                        }
+                    }
+                    Event::Code(code) => {
+                        if let Some(cap) = file_re.captures(&code) {
+                            let p = cap.get(1).unwrap().as_str();
+                            if !Path::new(p).exists() {
+                                missing
+                                    .push(format!("{}: missing file {p}", entry.path().display()));
+                            }
+                        } else if let Some(cap) = func_re.captures(&code) {
+                            let name = cap.get(1).unwrap().as_str();
+                            if !function_exists(name)? {
+                                missing.push(format!(
+                                    "{}: missing function {name}",
+                                    entry.path().display()
+                                ));
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    if !missing.is_empty() {
+        for m in &missing {
+            eprintln!("{m}");
+        }
+        std::process::exit(1);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement `check-docs` binary verifying file and function references in Markdown docs
- run the new checker in CI

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo run --bin check-docs`


------
https://chatgpt.com/codex/tasks/task_e_6867a65e505c83329647b0e53751f730