### PR TITLE
Add complex Markdown integration test

### DIFF
--- a/tests/complex.md
+++ b/tests/complex.md
@@ -1,0 +1,31 @@
+Title: Complex Example
+Number: 999
+Date: 2025-07-10
+
+## Nested List
+- Item 1
+  - Sub Item 1
+    - Sub Sub Item 1
+      - Deep Item
+- Item 2
+
+## Quote Block
+> First level quote line 1
+> First level quote line 2
+>
+> > Nested quote line
+>
+> Back to first level
+
+## Code Block
+```rust
+fn greet() {
+    println!("Hello, world!");
+}
+```
+
+## Table Example
+| Short | Much Longer Column | C |
+|-------|--------------------|---|
+| 1     | a                  | 3 |
+| 2     | abcdef             | 44 |

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -1,0 +1,28 @@
+*Часть 1/1*
+**Complex Example** — \#999 — 2025\-07\-10
+
+\-\-\-
+
+📰 **NESTED LIST**
+• Item 1
+  • Sub Item 1
+    • Sub Sub Item 1
+      • Deep Item
+• Item 2
+
+📰 **QUOTE BLOCK**
+\> First level quote line 1 First level quote line 2
+\> Nested quote line
+
+Back to first level
+
+📰 **CODE BLOCK**
+
+📰 **TABLE EXAMPLE**
+| Short | Much Longer Column | C  |
+| 1     | a                  | 3  |
+| 2     | abcdef             | 44 |
+
+\-\-\-
+
+Полный выпуск: [https://this\-week\-in\-rust\.org/blog/2025/07/10/this\-week\-in\-rust\-999/](https://this-week-in-rust.org/blog/2025/07/10/this-week-in-rust-999/)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -30,3 +30,16 @@ fn parse_latest_issue_full() {
         assert_eq!(post, exp, "Mismatch in post {}", i + 1);
     }
 }
+
+#[test]
+fn parse_complex_markdown() {
+    let input = include_str!("complex.md");
+    let posts = generate_posts(input.to_string());
+
+    let expected = [include_str!("expected/complex1.md")];
+
+    assert_eq!(posts.len(), expected.len(), "post count mismatch");
+    for (i, (post, exp)) in posts.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(post, exp, "Mismatch in post {}", i + 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add new complex Markdown input covering deep lists, quotes, code block and table
- include the expected output for this example
- validate parsing via new `parse_complex_markdown` test

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6867a65c517c8332a125c8cf35572d1d