### PR TITLE
Fix rustfmt for CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           profile: minimal
-      - run: rustup component add clippy rustfmt
+      - run: rustup component add --toolchain ${{ matrix.toolchain }} clippy rustfmt
       - run: cargo +${{ matrix.toolchain }} fmt --all -- --check
       - run: cargo +${{ matrix.toolchain }} check --all-targets --all-features
       - run: cargo +${{ matrix.toolchain }} clippy --all-targets --all-features -- -D warnings
@@ -52,7 +52,7 @@ jobs:
         with:
           toolchain: "1.88.0"
           profile: minimal
-      - run: rustup component add clippy rustfmt
+      - run: rustup component add --toolchain 1.88.0 clippy rustfmt
       - run: cargo +1.88.0 install cargo-tarpaulin
       - run: cargo +1.88.0 tarpaulin --out Lcov --output-dir coverage
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- make sure each CI toolchain has clippy and rustfmt installed

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6867ac7c79a883329ee69bb5ba0f4574