### PR TITLE
Fix deploy workflow binary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
           last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
           if [ "$GITHUB_EVENT_NAME" != "schedule" ] || [ "$latest_post" != "$last_sent" ]; then
             rm -f output_*.md
-            cargo run -- "$latest_post"
+            cargo run --bin twir-deploy-notify -- "$latest_post"
             for file in $(ls -v output_*.md 2>/dev/null); do
               text=$(cat "$file")
               resp=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ git clone https://github.com/rust-lang/this-week-in-rust twir
 After that you can run the tool manually with:
 
 ```bash
-cargo run -- twir/content/<file-name>.md
+cargo run --bin twir-deploy-notify -- twir/content/<file-name>.md
 ```
 
 Set `RUST_LOG=info` to see detailed logs including Telegram API responses:
 
 ```bash
-RUST_LOG=info cargo run -- twir/content/<file-name>.md
+RUST_LOG=info cargo run --bin twir-deploy-notify -- twir/content/<file-name>.md
 ```
 
 The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.


### PR DESCRIPTION
## Summary
- specify `twir-deploy-notify` binary in deploy workflow
- update README instructions accordingly

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6867b182000c8332b6c2e0ac857edd90