### PR TITLE
Add plain Telegram option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,7 +32,7 @@ pub fn main() -> std::io::Result<()> {
     {
         let base = env::var("TELEGRAM_API_BASE")
             .unwrap_or_else(|_| "https://api.telegram.org".to_string());
-        send_to_telegram(&posts, &base, &token, &chat_id)
+        send_to_telegram(&posts, &base, &token, &chat_id, !cli.plain)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
     }
     Ok(())

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -204,6 +204,7 @@ pub fn send_to_telegram(
     base_url: &str,
     token: &str,
     chat_id: &str,
+    use_markdown: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let client = Client::new();
     info!("Sending {} posts", posts.len());
@@ -214,15 +215,13 @@ pub fn send_to_telegram(
             token
         );
         debug!("Posting message {} to {}", i + 1, url);
-        let resp = client
-            .post(&url)
-            .form(&[
-                ("chat_id", chat_id),
-                ("text", post),
-                ("parse_mode", "MarkdownV2"),
-                ("disable_web_page_preview", "true"),
-            ])
-            .send()?;
+        let mut form = vec![("chat_id", chat_id), ("text", post)];
+        if use_markdown {
+            form.push(("parse_mode", "MarkdownV2"));
+        }
+        form.push(("disable_web_page_preview", "true"));
+
+        let resp = client.post(&url).form(&form).send()?;
         let status = resp.status();
         let body = resp.text()?;
         debug!("Telegram response {status}: {body}");


### PR DESCRIPTION
## Summary
- support optional Markdown in Telegram sender
- pass `--plain` to skip `parse_mode` parameter
- test for plain Telegram requests

## Testing
- `cargo test`
- `cargo test --features integration`
- `cargo machete`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets --all-features`


------
https://chatgpt.com/codex/tasks/task_e_6867b5a46a4c8332ae540a1fb4035165