### PR TITLE
Update docs with markdown verification notes

### DIFF
--- a/PARSING.md
+++ b/PARSING.md
@@ -3,3 +3,4 @@
 - Always use established crates like `pulldown-cmark` for reading and parsing Markdown files.
 - Avoid implementing Markdown parsing logic manually unless absolutely necessary.
 - Review all Markdown files in the repository before starting new tasks, as they may contain important instructions or data for the project.
+- Valid Telegram Markdown must be confirmed using an external library such as [`teloxide`](https://crates.io/crates/teloxide).

--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ The Telegram API response is checked with `jq`, and the workflow fails if the se
 ## Development
 
 Continuous integration runs `cargo machete --check` to verify that `Cargo.toml` lists only used dependencies. Run this command locally before opening a pull request.
+
+Documentation Markdown is validated with `cargo run --bin check-docs`, which parses files using [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark).


### PR DESCRIPTION
## Summary
- mention how markdown docs are validated in README
- state that Telegram Markdown validity relies on an external crate in PARSING guidelines

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6867cf24d01c8332924eb12f38b5c68d