### PR TITLE
Add Telegram Markdown validation

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -407,6 +407,9 @@ mod tests {
                 prop_assert!(!posts.is_empty());
                 for p in posts {
                     prop_assert!(p.len() <= TELEGRAM_LIMIT + 50);
+                    if let Err(e) = crate::validator::validate_telegram_markdown(&p) {
+                        return Err(TestCaseError::fail(e.to_string()));
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod generator;
 mod parser;
+mod validator;
 
 fn main() -> std::io::Result<()> {
     cli::main()

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,0 +1,112 @@
+use std::collections::VecDeque;
+
+/// Validate that the provided text conforms to Telegram Markdown v2 rules
+/// used in this project. Returns `Ok(())` if valid, otherwise an error
+/// message describing the first encountered problem.
+#[allow(dead_code)]
+pub fn validate_telegram_markdown(text: &str) -> Result<(), String> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut stack: VecDeque<&str> = VecDeque::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let ch = chars[i];
+        match ch {
+            '*' => {
+                let token = if i + 1 < chars.len() && chars[i + 1] == '*' {
+                    i += 1;
+                    "**"
+                } else {
+                    "*"
+                };
+                toggle_token(token, &mut stack)?;
+            }
+            '_' => {
+                let token = if i + 1 < chars.len() && chars[i + 1] == '_' {
+                    i += 1;
+                    "__"
+                } else {
+                    "_"
+                };
+                toggle_token(token, &mut stack)?;
+            }
+            '~' => toggle_token("~", &mut stack)?,
+            '|' => {
+                if i + 1 < chars.len() && chars[i + 1] == '|' {
+                    i += 1;
+                    toggle_token("||", &mut stack)?;
+                }
+            }
+            '`' => {
+                let token = if i + 2 < chars.len() && chars[i + 1] == '`' && chars[i + 2] == '`' {
+                    i += 2;
+                    "```"
+                } else {
+                    "`"
+                };
+                toggle_token(token, &mut stack)?;
+            }
+            '[' => {
+                let mut j = i + 1;
+                while j < chars.len() {
+                    if chars[j] == '\\' {
+                        j += 1;
+                    } else if chars[j] == ']' {
+                        break;
+                    }
+                    j += 1;
+                }
+                if j >= chars.len() || j + 1 >= chars.len() || chars[j + 1] != '(' {
+                    return Err(format!("Unmatched [ at {i}"));
+                }
+                j += 2;
+                while j < chars.len() {
+                    if chars[j] == '\\' {
+                        j += 1;
+                    } else if chars[j] == ')' {
+                        break;
+                    }
+                    j += 1;
+                }
+                if j >= chars.len() {
+                    return Err(format!("Unmatched [ at {i}"));
+                }
+                i = j;
+            }
+            '\\' => {
+                i += 1; // skip escaped char
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if let Some(tok) = stack.pop_back() {
+        return Err(format!("Unclosed {tok} entity"));
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn toggle_token<'a>(token: &'a str, stack: &mut VecDeque<&'a str>) -> Result<(), String> {
+    if let Some(last) = stack.back() {
+        if *last == token {
+            stack.pop_back();
+            return Ok(());
+        }
+        if stack.contains(&token) {
+            return Err(format!("Mismatched {token} entity"));
+        }
+    }
+    stack.push_back(token);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_validation() {
+        validate_telegram_markdown("*bold*").unwrap();
+        assert!(validate_telegram_markdown("*bold").is_err());
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,6 +3,11 @@ use std::process::Command;
 
 #[cfg(feature = "integration")]
 use mockito::Matcher;
+#[allow(dead_code)]
+#[path = "../src/validator.rs"]
+mod validator;
+
+use validator::validate_telegram_markdown;
 
 #[test]
 fn crate_of_the_week_is_preserved() {
@@ -21,6 +26,7 @@ fn crate_of_the_week_is_preserved() {
     let output = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
     assert!(output.contains("📰 **CRATE OF THE WEEK**"));
     assert!(output.contains("primitive\\_fixed\\_point\\_decimal"));
+    validate_telegram_markdown(&output).unwrap();
 }
 
 #[test]
@@ -41,6 +47,7 @@ fn crate_of_week_followed_by_section() {
     assert!(combined.contains("📰 **CRATE OF THE WEEK**"));
     assert!(combined.contains("[demo](https://example.com)"));
     assert!(combined.contains("📰 **NEXT**"));
+    validate_telegram_markdown(&combined).unwrap();
 }
 
 #[cfg(feature = "integration")]
@@ -73,6 +80,8 @@ fn telegram_request_sent() {
         .status()
         .expect("failed to run binary");
     assert!(status.success());
+    let post = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
+    validate_telegram_markdown(&post).unwrap();
     m.assert();
 }
 
@@ -108,5 +117,7 @@ fn telegram_request_sent_plain() {
         .status()
         .expect("failed to run binary");
     assert!(status.success());
+    let post = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
+    validate_telegram_markdown(&post).unwrap();
     m.assert();
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,8 +4,12 @@ mod generator;
 #[allow(dead_code)]
 #[path = "../src/parser.rs"]
 mod parser;
+#[allow(dead_code)]
+#[path = "../src/validator.rs"]
+mod validator;
 
 use generator::generate_posts;
+use validator::validate_telegram_markdown;
 
 #[test]
 fn parse_latest_issue_full() {
@@ -63,5 +67,16 @@ fn parse_issue_606_full() {
     assert_eq!(posts.len(), expected.len(), "post count mismatch");
     for (i, (post, exp)) in posts.iter().zip(expected.iter()).enumerate() {
         assert_eq!(post, exp, "Mismatch in post {}", i + 1);
+    }
+}
+
+#[test]
+fn validate_generated_posts() {
+    let input = include_str!("2025-06-25-this-week-in-rust.md");
+    let posts = generate_posts(input.to_string());
+    assert!(!posts.is_empty());
+    for (i, post) in posts.iter().enumerate() {
+        validate_telegram_markdown(post)
+            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
     }
 }

--- a/tests/telegram_e2e.rs
+++ b/tests/telegram_e2e.rs
@@ -6,11 +6,15 @@ mod generator;
 #[allow(dead_code)]
 #[path = "../src/parser.rs"]
 mod parser;
+#[allow(dead_code)]
+#[path = "../src/validator.rs"]
+mod validator;
 
 use generator::{generate_posts, send_to_telegram};
 use reqwest::blocking::Client;
 use serde_json::Value;
 use std::env;
+use validator::validate_telegram_markdown;
 
 #[test]
 fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -47,6 +51,9 @@ fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 
     let input = include_str!("2025-06-25-this-week-in-rust.md");
     let posts = generate_posts(input.to_string());
+    for (i, p) in posts.iter().enumerate() {
+        validate_telegram_markdown(p).unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    }
     send_to_telegram(&posts, &base, &token, &chat_id, true)?;
 
     let updates_url = format!(


### PR DESCRIPTION
## Summary
- implement Telegram Markdown validator
- ensure integration tests validate generated posts
- validate property-based test outputs

## Testing
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6867cf21333083329d285bd29681d967