### PR TITLE
Add tests for markdown validation errors

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -393,6 +393,13 @@ mod tests {
         assert!(validate_telegram_markdown("bad *text").is_err());
     }
 
+    #[test]
+    fn send_to_telegram_errors_on_invalid_markdown() {
+        let posts = vec!["bad *text".to_string()];
+        let err = send_to_telegram(&posts, "http://example.com", "TOKEN", "42", true);
+        assert!(err.is_err());
+    }
+
     mod property {
         use super::*;
         use proptest::prelude::*;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -85,6 +85,24 @@ fn telegram_request_sent() {
     m.assert();
 }
 
+#[test]
+fn fails_on_unescaped_markdown() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = "Title: Test\nNumber: 1\nDate: 2025-01-01\n\n## News\n- bad *text\n";
+    let input_path = dir.path().join("input.md");
+    fs::write(&input_path, input).unwrap();
+
+    let status = Command::new(env!("CARGO_BIN_EXE_twir-deploy-notify"))
+        .arg(&input_path)
+        .current_dir(dir.path())
+        .env("TELEGRAM_BOT_TOKEN", "TEST")
+        .env("TELEGRAM_CHAT_ID", "42")
+        .env("TELEGRAM_API_BASE", "http://example.com")
+        .status()
+        .expect("failed to run binary");
+    assert!(!status.success());
+}
+
 #[cfg(feature = "integration")]
 #[test]
 fn telegram_request_sent_plain() {


### PR DESCRIPTION
## Summary
- test error path in `send_to_telegram`
- add integration test for failing CLI invocation

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6867e1e532708332a797b427d317f96f