### PR TITLE
Add dash validation and tests

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -75,6 +75,11 @@ pub fn validate_telegram_markdown(text: &str) -> Result<(), String> {
             '\\' => {
                 i += 1; // skip escaped char
             }
+            '-' | '>' | '#' | '+' | '=' | '{' | '}' | '.' | '!' => {
+                if i == 0 || chars[i - 1] != '\\' {
+                    return Err(format!("Unescaped {ch} at {i}"));
+                }
+            }
             _ => {}
         }
         i += 1;
@@ -108,5 +113,15 @@ mod tests {
     fn basic_validation() {
         validate_telegram_markdown("*bold*").unwrap();
         assert!(validate_telegram_markdown("*bold").is_err());
+    }
+
+    #[test]
+    fn rejects_unescaped_dash() {
+        assert!(validate_telegram_markdown("some - text").is_err());
+    }
+
+    #[test]
+    fn accepts_escaped_dash() {
+        assert!(validate_telegram_markdown("some \\- text").is_ok());
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -103,6 +103,24 @@ fn fails_on_unescaped_markdown() {
     assert!(!status.success());
 }
 
+#[test]
+fn fails_on_unescaped_dash() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = "Title: Test\nNumber: 1\nDate: 2025-01-01\n\n## News\nsome - text\n";
+    let input_path = dir.path().join("input.md");
+    fs::write(&input_path, input).unwrap();
+
+    let status = Command::new(env!("CARGO_BIN_EXE_twir-deploy-notify"))
+        .arg(&input_path)
+        .current_dir(dir.path())
+        .env("TELEGRAM_BOT_TOKEN", "TEST")
+        .env("TELEGRAM_CHAT_ID", "42")
+        .env("TELEGRAM_API_BASE", "http://example.com")
+        .status()
+        .expect("failed to run binary");
+    assert!(!status.success());
+}
+
 #[cfg(feature = "integration")]
 #[test]
 fn telegram_request_sent_plain() {


### PR DESCRIPTION
## Summary
- validate dashes and reserved characters in Telegram Markdown
- ensure validation rejects unescaped dash
- test CLI behavior with unescaped dash input

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6868295f996883328f0ab47cc7e3dbcf