### PR TITLE
Add quiet flags to CI cargo commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,7 +51,7 @@ jobs:
           last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
           if [ "$GITHUB_EVENT_NAME" != "schedule" ] || [ "$latest_post" != "$last_sent" ]; then
             rm -f output_*.md
-            cargo run --bin twir-deploy-notify -- "$latest_post"
+            cargo run --quiet --bin twir-deploy-notify -- "$latest_post"
             for file in $(ls -v output_*.md 2>/dev/null); do
               text=$(cat "$file")
               resp=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   integration:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -28,7 +30,7 @@ jobs:
           toolchain: stable
           profile: minimal
       - run: rustup component add clippy rustfmt
-      - run: cargo fmt --all -- --check
-      - run: cargo check --all-targets --features integration
-      - run: cargo clippy --all-targets --features integration -- -D warnings
-      - run: cargo test --all-targets --features integration -- --test-threads=$(nproc)
+      - run: cargo fmt --quiet --all -- --check
+      - run: cargo check --quiet --all-targets --features integration
+      - run: cargo clippy --quiet --all-targets --features integration -- -D warnings
+      - run: cargo test --quiet --all-targets --features integration -- --test-threads=$(nproc)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
     strategy:
       matrix:
         toolchain: ["1.88.0", beta, nightly]
@@ -30,14 +32,16 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           profile: minimal
       - run: rustup component add --toolchain ${{ matrix.toolchain }} clippy rustfmt
-      - run: cargo +${{ matrix.toolchain }} fmt --all -- --check
-      - run: cargo +${{ matrix.toolchain }} check --all-targets --all-features
-      - run: cargo +${{ matrix.toolchain }} clippy --all-targets --all-features -- -D warnings
-      - run: cargo +${{ matrix.toolchain }} test --all-targets --all-features -- --test-threads=$(nproc)
-      - run: cargo +${{ matrix.toolchain }} run --bin check-docs
+      - run: cargo +${{ matrix.toolchain }} fmt --quiet --all -- --check
+      - run: cargo +${{ matrix.toolchain }} check --quiet --all-targets --all-features
+      - run: cargo +${{ matrix.toolchain }} clippy --quiet --all-targets --all-features -- -D warnings
+      - run: cargo +${{ matrix.toolchain }} test --quiet --all-targets --all-features -- --test-threads=$(nproc)
+      - run: cargo +${{ matrix.toolchain }} run --quiet --bin check-docs
 
   coverage:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -53,8 +57,8 @@ jobs:
           toolchain: "1.88.0"
           profile: minimal
       - run: rustup component add --toolchain 1.88.0 clippy rustfmt
-      - run: cargo +1.88.0 install cargo-tarpaulin
-      - run: cargo +1.88.0 tarpaulin --out Lcov --output-dir coverage
+      - run: cargo +1.88.0 install cargo-tarpaulin --quiet
+      - run: cargo +1.88.0 tarpaulin --out Lcov --output-dir coverage --quiet
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-report


### PR DESCRIPTION
## Summary
- suppress compiler progress output in CI
- ensure progress bars never appear in pipeline logs

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)` *(fails: full_issue_end_to_end)*
- `cargo machete` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868607874988332a218fea1523f2f24