### PR TITLE
Add cargo-machete step to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,13 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           profile: minimal
+      - run: cargo install cargo-machete --quiet
       - run: rustup component add --toolchain ${{ matrix.toolchain }} clippy rustfmt
       - run: cargo +${{ matrix.toolchain }} fmt --quiet --all -- --check
       - run: cargo +${{ matrix.toolchain }} check --quiet --all-targets --all-features
       - run: cargo +${{ matrix.toolchain }} clippy --quiet --all-targets --all-features -- -D warnings
       - run: cargo +${{ matrix.toolchain }} test --quiet --all-targets --all-features -- --test-threads=$(nproc)
+      - run: cargo +${{ matrix.toolchain }} machete --quiet
       - run: cargo +${{ matrix.toolchain }} run --quiet --bin check-docs
 
   coverage:


### PR DESCRIPTION
## Summary
- install `cargo-machete` in GitHub Actions
- run `cargo machete` after the tests

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869043a1b708332b36e32fb479ab991