### PR TITLE
Replace example URL in tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -102,7 +102,8 @@ fn fails_on_unescaped_markdown() {
         .current_dir(dir.path())
         .env("TELEGRAM_BOT_TOKEN", "TEST")
         .env("TELEGRAM_CHAT_ID", "42")
-        .env("TELEGRAM_API_BASE", "http://example.com")
+        // Use example.invalid to avoid accidental network calls
+        .env("TELEGRAM_API_BASE", "http://example.invalid")
         .status()
         .expect("failed to run binary");
     assert!(!status.success());
@@ -120,7 +121,8 @@ fn fails_on_unescaped_dash() {
         .current_dir(dir.path())
         .env("TELEGRAM_BOT_TOKEN", "TEST")
         .env("TELEGRAM_CHAT_ID", "42")
-        .env("TELEGRAM_API_BASE", "http://example.com")
+        // Use example.invalid to avoid accidental network calls
+        .env("TELEGRAM_API_BASE", "http://example.invalid")
         .status()
         .expect("failed to run binary");
     assert!(!status.success());


### PR DESCRIPTION
## Summary
- avoid real network calls in integration tests by using `example.invalid`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686907baf2d4833290d19e6d2bb537d2