### PR TITLE
Обновление вызова tarpaulin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           profile: minimal
       - run: rustup component add --toolchain stable clippy rustfmt
       - run: cargo +stable install cargo-tarpaulin --quiet
-      - run: cargo +stable tarpaulin --out Lcov --output-dir coverage --quiet
+      - run: cargo +stable tarpaulin --out Lcov --output-dir coverage -- --quiet
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,5 @@
   commit.
 - Read all Markdown (`*.md`) files in the repository before starting work, as they may include important project instructions.
 - Follow the guidelines in `PARSING.md`, especially the requirement to rely on crates for Markdown processing instead of custom parsing code.
+
+- Avoid committed dead code; remove unused functions or feature-gate them.


### PR DESCRIPTION
## Изменения
- исправлена команда запуска tarpaulin в CI

## Тестирование
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68690baf52c8833281933356fe07200a