### PR TITLE
Remove quiet flag from machete step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - run: cargo +${{ matrix.toolchain }} check --quiet --all-targets --all-features
       - run: cargo +${{ matrix.toolchain }} clippy --quiet --all-targets --all-features -- -D warnings
       - run: cargo +${{ matrix.toolchain }} test --quiet --all-targets --all-features -- --test-threads=$(nproc)
-      - run: cargo +${{ matrix.toolchain }} machete --quiet
+      - run: cargo +${{ matrix.toolchain }} machete
       - run: cargo +${{ matrix.toolchain }} run --quiet --bin check-docs
 
   coverage:


### PR DESCRIPTION
## Summary
- run `cargo machete` without the quiet flag

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68690b74cd1c8332a97af3e5455263a0