### PR TITLE
Update docs for split_posts escapes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ This tool processes weekly "This Week in Rust" Markdown files and prepares messa
 
 ## Message Generation
 - Each section becomes a separate Telegram post capped at 4000 characters.
-- Long messages are split, and overly long lines are divided while preserving escape sequences. Each post is prefixed with `*Часть X/Y*`.
+- Long messages are split by `split_posts`, which scans for escaped characters when breaking lines so that Telegram accepts every chunk. Each post is prefixed with `*Часть X/Y*`.
 - The optional `--plain` flag removes Markdown formatting for channels that require plain text.
 
 ## Dependencies

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -15,3 +15,7 @@
 - Updated deploy workflow to skip previous version checks when the run is not triggered by the scheduler.
 - Fixed message splitting logic to respect Telegram limits and updated integration tests.
 - Enhanced post splitting to cut within overly long lines while preserving escapes.
+
+## 2025-07-05
+- Identified an issue with `split_posts` cutting lines after escape characters.
+- Added regression tests in `tests/generator.rs` verifying correct line splitting.


### PR DESCRIPTION
## Summary
- log string split issue in DEVLOG
- clarify in ARCHITECTURE that `split_posts` considers escape sequences

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68691fea56e88332b2b37c92f3ef0465