### PR TITLE
Fix split_posts escaping at chunk boundaries

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -94,13 +94,11 @@ pub fn split_posts(text: &str, limit: usize) -> Vec<String> {
             let mut chunk = String::new();
             for c in line.chars() {
                 if chunk.len() + c.len_utf8() > limit {
-                    let backslashes = chunk.chars().rev().take_while(|ch| *ch == '\\').count();
-                    if backslashes % 2 == 1 {
-                        if let Some(bs) = chunk.pop() {
-                            posts.push(chunk.clone());
-                            chunk.clear();
-                            chunk.push(bs);
-                        }
+                    if chunk.ends_with('\\') {
+                        chunk.pop();
+                        posts.push(chunk.clone());
+                        chunk.clear();
+                        chunk.push('\\');
                     } else {
                         posts.push(chunk.clone());
                         chunk.clear();
@@ -122,8 +120,15 @@ pub fn split_posts(text: &str, limit: usize) -> Vec<String> {
         };
 
         if new_len > limit && !current.is_empty() {
-            posts.push(current.clone());
-            current.clear();
+            if current.ends_with('\\') {
+                current.pop();
+                posts.push(current.clone());
+                current.clear();
+                current.push('\\');
+            } else {
+                posts.push(current.clone());
+                current.clear();
+            }
         }
 
         if !current.is_empty() {

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -10,6 +10,7 @@ mod validator;
 
 use generator::{TELEGRAM_LIMIT, split_posts};
 use proptest::prelude::*;
+use validator::validate_telegram_markdown;
 
 fn arb_long_line() -> impl Strategy<Value = String> {
     let regex = format!(
@@ -17,6 +18,13 @@ fn arb_long_line() -> impl Strategy<Value = String> {
         TELEGRAM_LIMIT * 2,
         TELEGRAM_LIMIT * 3
     );
+    proptest::string::string_regex(&regex).unwrap()
+}
+
+fn arb_escaped_text() -> impl Strategy<Value = String> {
+    let lower = TELEGRAM_LIMIT - 5;
+    let upper = TELEGRAM_LIMIT + 5;
+    let regex = format!(r"(?:[A-Za-z]|\\\\[-!#\\.]){{{lower},{upper}}}");
     proptest::string::string_regex(&regex).unwrap()
 }
 
@@ -29,6 +37,18 @@ proptest! {
         prop_assert!(!posts.is_empty());
         for p in posts {
             prop_assert!(p.len() <= TELEGRAM_LIMIT);
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(16))]
+    #[test]
+    fn escaped_chunks_are_valid(line in arb_escaped_text()) {
+        let posts = split_posts(&line, TELEGRAM_LIMIT);
+        prop_assert!(!posts.is_empty());
+        for p in posts {
+            prop_assert!(validate_telegram_markdown(&p).is_ok());
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep trailing escapes with next char when splitting
- expand tests with property to validate escaped chunks
- ensure send_to_telegram succeeds for long escaped dash

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68691fe9ceec8332a0522bc555f8e461