### PR TITLE
Fix dash escape tests

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -408,6 +408,33 @@ mod tests {
     }
 
     #[test]
+    fn subheading_with_dash() {
+        let text = "## Section\n### Foo-Bar\n- item\n";
+        let secs = parse_sections(text);
+        assert_eq!(secs[0].lines[0], "**Foo\\\\-Bar**");
+        let posts = generate_posts(
+            "Title: T\nNumber: 1\nDate: 2025-01-01\n\n## Section\n### Foo-Bar\n- item\n"
+                .to_string(),
+        );
+        for p in posts {
+            crate::validator::validate_telegram_markdown(&p).unwrap();
+        }
+    }
+
+    #[test]
+    fn dash_at_post_boundary() {
+        let mut text = "a".repeat(10);
+        text.push('\n');
+        text.push_str("\\- start");
+        let parts = split_posts(&text, 10);
+        assert!(parts.len() > 1);
+        assert!(parts[1].starts_with("\\-"));
+        for p in parts {
+            crate::validator::validate_telegram_markdown(&p).unwrap();
+        }
+    }
+
+    #[test]
     fn markdown_validation() {
         assert!(crate::validator::validate_telegram_markdown("simple text").is_ok());
         assert!(crate::validator::validate_telegram_markdown("bad *text").is_err());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,7 +20,7 @@ fn fix_bare_link(line: &str) -> String {
     if let Some(caps) = BARE_LINK_RE.captures(line) {
         let url = caps.get(1).unwrap().as_str();
         let text = line[..caps.get(0).unwrap().start()].trim_end();
-        format!("[{text}]({url})")
+        format!("[{text}]({})", escape_markdown_url(url))
     } else {
         line.to_string()
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -105,6 +105,14 @@ fn validate_issue_606_posts() {
 }
 
 #[test]
+fn validate_issue_606_post_4() {
+    let input = include_str!("2025-07-02-this-week-in-rust.md");
+    let posts = generate_posts(input.to_string());
+    assert!(posts.len() >= 4);
+    validate_telegram_markdown(&posts[3]).unwrap();
+}
+
+#[test]
 fn validate_complex_posts() {
     let input = include_str!("complex.md");
     let posts = generate_posts(input.to_string());


### PR DESCRIPTION
## Summary
- ensure bare links escape URLs before formatting
- test subheadings and post boundaries with dashes
- verify the fourth post of issue 606
- expose generator and parser modules to integration tests

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68691fdea3288332b3a060d3de62c0f1