### PR TITLE
Fix split boundary escapes

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -84,6 +84,10 @@ pub fn split_posts(text: &str, limit: usize) -> Vec<String> {
     let mut posts = Vec::new();
     let mut current = String::new();
 
+    fn needs_escape(c: char) -> bool {
+        matches!(c, '-' | '>' | '#' | '+' | '=' | '{' | '}' | '.' | '!')
+    }
+
     for line in text.lines() {
         if line.len() > limit {
             if !current.is_empty() {
@@ -102,6 +106,9 @@ pub fn split_posts(text: &str, limit: usize) -> Vec<String> {
                     } else {
                         posts.push(chunk.clone());
                         chunk.clear();
+                        if needs_escape(c) {
+                            chunk.push('\\');
+                        }
                     }
                 }
                 chunk.push(c);
@@ -133,6 +140,13 @@ pub fn split_posts(text: &str, limit: usize) -> Vec<String> {
 
         if !current.is_empty() {
             current.push('\n');
+        }
+        if current.is_empty() {
+            if let Some(first) = line.chars().next() {
+                if needs_escape(first) && !line.starts_with('\\') {
+                    current.push('\\');
+                }
+            }
         }
         current.push_str(line);
     }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -6,6 +6,11 @@ use std::collections::VecDeque;
 pub fn validate_telegram_markdown(text: &str) -> Result<(), String> {
     let chars: Vec<char> = text.chars().collect();
     let mut stack: VecDeque<&str> = VecDeque::new();
+    if let Some(&first) = chars.first() {
+        if matches!(first, '-' | '>' | '#' | '+' | '=' | '{' | '}' | '.' | '!') {
+            return Err("Post starts with reserved character".to_string());
+        }
+    }
     let mut i = 0;
     while i < chars.len() {
         let ch = chars[i];

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -52,3 +52,16 @@ proptest! {
         }
     }
 }
+
+#[test]
+fn boundary_escape_preserved() {
+    let mut input = "a".repeat(TELEGRAM_LIMIT - 1);
+    input.push('\\');
+    input.push_str("-b");
+    let posts = split_posts(&input, TELEGRAM_LIMIT);
+    assert!(posts.len() >= 2);
+    assert!(!posts[1].starts_with('-'));
+    for p in posts {
+        validate_telegram_markdown(&p).unwrap();
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -157,3 +157,17 @@ fn send_long_escaped_dash() {
         m.assert();
     }
 }
+
+#[test]
+fn issue_606_no_unescaped_dashes() {
+    let input = include_str!("2025-07-02-this-week-in-rust.md");
+    let posts = generate_posts(input.to_string());
+    assert!(!posts.is_empty());
+    for (i, post) in posts.iter().enumerate() {
+        assert!(
+            !post.starts_with('-'),
+            "post {} begins with unescaped dash",
+            i + 1
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- adjust `split_posts` to escape reserved chars at boundaries
- reject posts starting with reserved char
- check boundary escapes in generator tests
- ensure issue 606 posts don't start with dash

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68692beb0cdc83328a170a8bb4fcf172