### PR TITLE
Handle parentheses in bare links

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,16 +11,17 @@ pub struct Section {
     pub lines: Vec<String>,
 }
 
-static BARE_LINK_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\((https?://[^\)]+)\)\s*$").unwrap());
+static BARE_LINK_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\((https?://.*)\)\s*$").unwrap());
 
 fn fix_bare_link(line: &str) -> String {
     if line.contains("](") {
         return line.to_string();
     }
     if let Some(caps) = BARE_LINK_RE.captures(line) {
-        let url = caps.get(1).unwrap().as_str();
-        let text = line[..caps.get(0).unwrap().start()].trim_end();
-        format!("[{text}]({})", escape_markdown_url(url))
+        let url = caps.get(1).unwrap().as_str().replace('\\', "");
+        let text_raw = &line[..caps.get(0).unwrap().start()];
+        let text = text_raw.replace('\\', "").trim_end().to_string();
+        format!("[{text}]({})", escape_markdown_url(&url))
     } else {
         line.to_string()
     }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -18,3 +18,16 @@ fn code_block_before_next_heading() {
     assert_eq!(sections[0].title, "First");
     assert_eq!(sections[0].lines, vec!["```\nline1\nline2\n```"]);
 }
+
+#[test]
+fn bare_link_with_parentheses() {
+    let input = "## Section\n- Some text (https://example.com/path(1))";
+    let sections = parse_sections(input);
+    assert_eq!(sections.len(), 1);
+    assert_eq!(sections[0].title, "Section");
+    assert_eq!(
+        sections[0].lines,
+        vec!["• [Some text](https://example.com/path(1\\))"]
+    );
+    validator::validate_telegram_markdown(&sections[0].lines[0]).unwrap();
+}


### PR DESCRIPTION
## Summary
- escape bare links that contain parentheses
- test `bare_link_with_parentheses` to ensure parser escapes links correctly and passes Telegram validation

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68692ce17d048332af97f8ed6ab17cf4