### PR TITLE
Refactor CI workflows

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,24 @@
+name: 'Setup Rust'
+description: 'Checkout repository, setup cache and toolchain'
+inputs:
+  toolchain:
+    description: 'Rust toolchain'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo
+          target
+        key: ${{ runner.os }}-${{ inputs.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.toolchain }}-
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        profile: minimal
+    - run: rustup component add --toolchain ${{ inputs.toolchain }} clippy rustfmt
+      shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,26 +11,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  integration:
+  fmt:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo
-            target
-          key: ${{ runner.os }}-integration-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-integration-
-      - uses: actions-rs/toolchain@v1
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: stable
-          profile: minimal
-      - run: rustup component add clippy rustfmt
       - run: cargo fmt --quiet --all -- --check
+
+  check:
+    needs: fmt
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
       - run: cargo check --quiet --all-targets --features integration
+
+  clippy:
+    needs: check
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
       - run: cargo clippy --quiet --all-targets --features integration -- -D warnings
+
+  test:
+    needs: clippy
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
       - run: cargo test --quiet --all-targets --features integration -- --test-threads=$(nproc)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,57 +10,83 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_PROGRESS_WHEN: never
-    strategy:
-      matrix:
-        toolchain: [stable]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo
-            target
-          key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.toolchain }}-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          profile: minimal
-      - run: cargo install cargo-machete --quiet
-      - run: rustup component add --toolchain ${{ matrix.toolchain }} clippy rustfmt
-      - run: cargo +${{ matrix.toolchain }} fmt --quiet --all -- --check
-      - run: cargo +${{ matrix.toolchain }} check --quiet --all-targets --all-features
-      - run: cargo +${{ matrix.toolchain }} clippy --quiet --all-targets --all-features -- -D warnings
-      - run: cargo +${{ matrix.toolchain }} test --quiet --all-targets --all-features -- --test-threads=$(nproc)
-      - run: cargo +${{ matrix.toolchain }} --quiet machete
-      - run: cargo +${{ matrix.toolchain }} run --quiet --bin check-docs
-
-  coverage:
+  fmt:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo
-            target
-          key: ${{ runner.os }}-coverage-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-coverage-
-      - uses: actions-rs/toolchain@v1
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: stable
-          profile: minimal
-      - run: rustup component add --toolchain stable clippy rustfmt
-      - run: cargo +stable install cargo-tarpaulin --quiet
-      - run: cargo +stable tarpaulin --out Lcov --output-dir coverage -- --quiet
+      - run: cargo fmt --quiet --all -- --check
+
+  check:
+    needs: fmt
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
+      - run: cargo check --quiet --all-targets --all-features
+
+  clippy:
+    needs: check
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
+      - run: cargo clippy --quiet --all-targets --all-features -- -D warnings
+
+  test:
+    needs: clippy
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
+      - run: cargo test --quiet --all-targets --all-features -- --test-threads=$(nproc)
+
+  machete:
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
+      - run: cargo install cargo-machete --quiet
+      - run: cargo machete
+
+  check-docs:
+    needs: machete
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
+      - run: cargo run --quiet --bin check-docs
+
+  coverage:
+    needs: check-docs
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
+      - run: cargo install cargo-tarpaulin --quiet
+      - run: cargo tarpaulin --out Lcov --output-dir coverage -- --quiet
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-report


### PR DESCRIPTION
## Summary
- refactor `CI` and `Integration Tests` workflows into multiple dependent jobs
- add reusable `setup-rust` composite action for shared steps

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68692d5854e483329f4ea31cb7f5358a