### PR TITLE
Add Markdown validation to post generation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ pub fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
 
     let input = fs::read_to_string(&cli.input)?;
-    let mut posts = generate_posts(input);
+    let mut posts = generate_posts(input).map_err(|e| std::io::Error::other(e.to_string()))?;
 
     if cli.plain {
         posts = posts.into_iter().map(|p| markdown_to_plain(&p)).collect();

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -144,7 +144,7 @@ pub fn split_posts(text: &str, limit: usize) -> Vec<String> {
     posts
 }
 
-pub fn generate_posts(mut input: String) -> Vec<String> {
+pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError> {
     let title = find_title(&input);
     let number = find_number(&input);
     let date = find_date(&input);
@@ -223,16 +223,17 @@ pub fn generate_posts(mut input: String) -> Vec<String> {
     }
 
     let total = final_posts.len();
-    final_posts
-        .into_iter()
-        .enumerate()
-        .map(|(i, mut post)| {
-            if !post.ends_with('\n') {
-                post.push('\n');
-            }
-            format!("*Часть {}/{}*\n{}", i + 1, total, post)
-        })
-        .collect()
+    let mut result = Vec::new();
+    for (i, mut post) in final_posts.into_iter().enumerate() {
+        if !post.ends_with('\n') {
+            post.push('\n');
+        }
+        let formatted = format!("*Часть {}/{}*\n{}", i + 1, total, post);
+        validate_telegram_markdown(&formatted)
+            .map_err(|e| ValidationError(format!("Generated post {} invalid: {e}", i + 1)))?;
+        result.push(formatted);
+    }
+    Ok(result)
 }
 
 pub fn write_posts(posts: &[String], dir: &Path) -> std::io::Result<()> {
@@ -315,7 +316,7 @@ mod tests {
     fn generate_and_write_files() {
         let input =
             "Title: Test\nNumber: 1\nDate: 2024-01-01\n\n## News\n- [Link](https://example.com)\n";
-        let posts = generate_posts(input.to_string());
+        let posts = generate_posts(input.to_string()).unwrap();
         let mut dir = std::env::temp_dir();
         dir.push("twir_test");
         let _ = fs::remove_dir_all(&dir);
@@ -375,7 +376,7 @@ mod tests {
     #[test]
     fn table_rendering() {
         let input = "Title: Test\nNumber: 1\nDate: 2024-01-01\n\n## Table\n| Name | Score |\n|------|------|\n| Foo | 10 |\n| Bar | 20 |\n";
-        let posts = generate_posts(input.to_string());
+        let posts = generate_posts(input.to_string()).unwrap();
         assert!(posts[0].contains("| Name | Score |"));
         assert!(posts[0].contains("| Foo  | 10    |"));
         assert!(posts[0].contains("| Bar  | 20    |"));
@@ -391,7 +392,8 @@ mod tests {
             secs[0].lines,
             vec!["\\> quoted text", "```\ncode line\n```"]
         );
-        let posts = generate_posts(format!("Title: T\nNumber: 1\nDate: 2025-01-01\n\n{text}"));
+        let posts =
+            generate_posts(format!("Title: T\nNumber: 1\nDate: 2025-01-01\n\n{text}")).unwrap();
         let combined = posts.join("\n");
         assert!(combined.contains("> quoted text"));
         assert!(combined.contains("```\ncode line\n```"));
@@ -420,7 +422,8 @@ mod tests {
         let posts = generate_posts(
             "Title: T\nNumber: 1\nDate: 2025-01-01\n\n## Section\n### Foo-Bar\n- item\n"
                 .to_string(),
-        );
+        )
+        .unwrap();
         for p in posts {
             crate::validator::validate_telegram_markdown(&p).unwrap();
         }
@@ -497,7 +500,10 @@ mod tests {
 
             #[test]
             fn random_inputs_are_split_correctly(input in arb_markdown()) {
-                let posts = generate_posts(input);
+                let posts = match generate_posts(input) {
+                    Ok(p) => p,
+                    Err(e) => return Err(TestCaseError::fail(e.to_string())),
+                };
                 prop_assert!(!posts.is_empty());
                 for p in posts {
                     prop_assert!(p.len() <= TELEGRAM_LIMIT + 50);

--- a/tests/dash_regression.rs
+++ b/tests/dash_regression.rs
@@ -15,7 +15,7 @@ use validator::validate_telegram_markdown;
 fn issue_606_dash_after_newline() {
     // Extract a post from the 2025-07-02 issue that begins with a dash
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     // Ensure at least one generated post contains an unescaped dash at the start
     let broken = posts.into_iter().find(|p| p.starts_with("-"));
     if let Some(post) = broken {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -261,7 +261,8 @@ fn full_issue_end_to_end() {
 #[test]
 fn send_issue_606_post_4() {
     let posts =
-        generator::generate_posts(include_str!("2025-07-02-this-week-in-rust.md").to_string());
+        generator::generate_posts(include_str!("2025-07-02-this-week-in-rust.md").to_string())
+            .unwrap();
     assert!(posts.len() > 3);
     let mut server = mockito::Server::new();
     let m = server

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,7 +15,7 @@ use validator::validate_telegram_markdown;
 #[test]
 fn parse_latest_issue_full() {
     let input = include_str!("2025-06-25-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/expected1.md"),
@@ -42,7 +42,7 @@ fn parse_latest_issue_full() {
 #[test]
 fn parse_complex_markdown() {
     let input = include_str!("complex.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/complex1.md"),
@@ -61,7 +61,7 @@ fn parse_complex_markdown() {
 #[test]
 fn parse_issue_606_full() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/606_1.md"),
@@ -86,7 +86,7 @@ fn parse_issue_606_full() {
 #[test]
 fn validate_generated_posts() {
     let input = include_str!("2025-06-25-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         validate_telegram_markdown(post)
@@ -97,7 +97,7 @@ fn validate_generated_posts() {
 #[test]
 fn validate_issue_606_posts() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         validate_telegram_markdown(post)
@@ -108,7 +108,7 @@ fn validate_issue_606_posts() {
 #[test]
 fn validate_issue_606_post_4() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(posts.len() >= 4);
     validate_telegram_markdown(&posts[3]).unwrap();
 }
@@ -116,7 +116,7 @@ fn validate_issue_606_post_4() {
 #[test]
 fn validate_complex_posts() {
     let input = include_str!("complex.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         validate_telegram_markdown(post)
@@ -130,7 +130,7 @@ fn send_long_escaped_dash() {
 
     let prefix = "a".repeat(generator::TELEGRAM_LIMIT - 1);
     let input = format!("Title: Test\nNumber: 1\nDate: 2025-01-01\n\n## News\n{prefix}\\-b");
-    let posts = generate_posts(input);
+    let posts = generate_posts(input).unwrap();
     assert!(!posts.is_empty());
 
     let mut server = mockito::Server::new();

--- a/tests/telegram_e2e.rs
+++ b/tests/telegram_e2e.rs
@@ -50,7 +50,7 @@ fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
     }
 
     let input = include_str!("2025-06-25-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     for (i, p) in posts.iter().enumerate() {
         validate_telegram_markdown(p).unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
     }


### PR DESCRIPTION
## Summary
- validate formatted posts inside `generate_posts`
- propagate validation errors in CLI
- adjust tests for new `generate_posts` result type

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68692cbf3c908332b62ef09b6623eac8