### PR TITLE
fix: escape bare links regression

### DIFF
--- a/tests/cfp_regression.rs
+++ b/tests/cfp_regression.rs
@@ -46,7 +46,7 @@ If you are an event organizer hoping to expand the reach of your event, please s
 #[test]
 fn cfp_section_generates_valid_markdown() {
     let input = format!("Title: Test\nNumber: 1\nDate: 2025-06-25\n\n{CFP_SNIPPET}");
-    let posts = generate_posts(input);
+    let posts = generate_posts(input).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         validate_telegram_markdown(post)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -84,20 +84,9 @@ fn parse_issue_606_full() {
 }
 
 #[test]
-fn parse_call_for_participation() {
-    let input = include_str!("2025-07-05-call-for-participation.md");
-    let posts = generate_posts(input.to_string());
-
-    let expected = [
-        include_str!("expected/cfp1.md"),
-        include_str!("expected/cfp2.md"),
-  ];
-}
-
-#[test]    
 fn parse_issue_607_full() {
     let input = include_str!("2025-07-05-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/607_1.md"),
@@ -199,7 +188,7 @@ fn send_long_escaped_dash() {
 #[test]
 fn issue_606_no_unescaped_dashes() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         assert!(
@@ -213,7 +202,7 @@ fn issue_606_no_unescaped_dashes() {
 #[test]
 fn parse_call_for_participation() {
     let input = include_str!("2025-07-05-call-for-participation.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/cfp1.md"),


### PR DESCRIPTION
## Summary
- cleanup integration tests after rebase
- unwrap result values in cfp regression test

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686934120e748332bc259c1ae4e01c34