### PR TITLE
Validate generated posts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ pub fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
 
     let input = fs::read_to_string(&cli.input)?;
-    let mut posts = generate_posts(input);
+    let mut posts = generate_posts(input).map_err(|e| std::io::Error::other(e.to_string()))?;
 
     if cli.plain {
         posts = posts.into_iter().map(|p| markdown_to_plain(&p)).collect();

--- a/tests/dash_regression.rs
+++ b/tests/dash_regression.rs
@@ -15,7 +15,7 @@ use validator::validate_telegram_markdown;
 fn issue_606_dash_after_newline() {
     // Extract a post from the 2025-07-02 issue that begins with a dash
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     // Ensure at least one generated post contains an unescaped dash at the start
     let broken = posts.into_iter().find(|p| p.starts_with("-"));
     if let Some(post) = broken {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,7 +15,7 @@ use validator::validate_telegram_markdown;
 #[test]
 fn parse_latest_issue_full() {
     let input = include_str!("2025-06-25-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/expected1.md"),
@@ -42,7 +42,7 @@ fn parse_latest_issue_full() {
 #[test]
 fn parse_complex_markdown() {
     let input = include_str!("complex.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/complex1.md"),
@@ -61,7 +61,7 @@ fn parse_complex_markdown() {
 #[test]
 fn parse_issue_606_full() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/606_1.md"),
@@ -86,7 +86,7 @@ fn parse_issue_606_full() {
 #[test]
 fn validate_generated_posts() {
     let input = include_str!("2025-06-25-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         validate_telegram_markdown(post)
@@ -97,7 +97,7 @@ fn validate_generated_posts() {
 #[test]
 fn validate_issue_606_posts() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         validate_telegram_markdown(post)
@@ -108,7 +108,7 @@ fn validate_issue_606_posts() {
 #[test]
 fn validate_issue_606_post_4() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(posts.len() >= 4);
     validate_telegram_markdown(&posts[3]).unwrap();
 }
@@ -116,7 +116,7 @@ fn validate_issue_606_post_4() {
 #[test]
 fn validate_complex_posts() {
     let input = include_str!("complex.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         validate_telegram_markdown(post)
@@ -130,7 +130,7 @@ fn send_long_escaped_dash() {
 
     let prefix = "a".repeat(generator::TELEGRAM_LIMIT - 1);
     let input = format!("Title: Test\nNumber: 1\nDate: 2025-01-01\n\n## News\n{prefix}\\-b");
-    let posts = generate_posts(input);
+    let posts = generate_posts(input).unwrap();
     assert!(!posts.is_empty());
 
     let mut server = mockito::Server::new();

--- a/tests/telegram_e2e.rs
+++ b/tests/telegram_e2e.rs
@@ -50,7 +50,7 @@ fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
     }
 
     let input = include_str!("2025-06-25-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     for (i, p) in posts.iter().enumerate() {
         validate_telegram_markdown(p).unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
     }


### PR DESCRIPTION
## Summary
- check Telegram Markdown when generating posts
- bubble up validation errors to CLI
- adjust tests to unwrap the Result from `generate_posts`

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68692ce13fc8833294b72f8d1b03d721