### PR TITLE
Pin GitHub Actions toolchain to 1.88.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.88.0
           profile: minimal
 
       - name: Send latest post to Telegram

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo fmt --quiet --all -- --check
 
   check:
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo check --quiet --all-targets --features integration
 
   clippy:
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo clippy --quiet --all-targets --features integration -- -D warnings
 
   test:
@@ -51,5 +51,5 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo test --quiet --all-targets --features integration -- --test-threads=$(nproc)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo fmt --quiet --all -- --check
 
   check:
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo check --quiet --all-targets --all-features
 
   clippy:
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo clippy --quiet --all-targets --all-features -- -D warnings
 
   test:
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo test --quiet --all-targets --all-features -- --test-threads=$(nproc)
 
   machete:
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo install cargo-machete --quiet
       - run: cargo machete
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo run --quiet --bin check-docs
 
   coverage:
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: 1.88.0
       - run: cargo install cargo-tarpaulin --quiet
       - run: cargo tarpaulin --out Lcov --output-dir coverage -- --quiet
       - uses: actions/upload-artifact@v4

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -64,7 +64,6 @@ proptest! {
     }
 }
 
-
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(16))]
     #[test]
@@ -72,17 +71,6 @@ proptest! {
         let posts = split_posts(&text, TELEGRAM_LIMIT);
         prop_assert!(!posts.is_empty());
     }
-}
-
-fn arb_dash_boundary() -> impl Strategy<Value = String> {
-    let prefix_regex = format!(r"[A-Za-z0-9]{{{}}}", TELEGRAM_LIMIT - 1);
-    proptest::string::string_regex(&prefix_regex)
-        .unwrap()
-        .prop_flat_map(|prefix| {
-            proptest::string::string_regex("[A-Za-z0-9]{0,20}")
-                .unwrap()
-                .prop_map(move |suffix| format!("{prefix}\\-{suffix}"))
-        })
 }
 
 proptest! {


### PR DESCRIPTION
## Summary
- use toolchain 1.88.0 in CI workflows
- remove duplicated test helper to fix compile error

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo install cargo-machete --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68693877c79c8332a449c14db9117df3