### PR TITLE
Fix duplicate generator test helper

### DIFF
--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -12,7 +12,7 @@ use generator::{TELEGRAM_LIMIT, split_posts};
 use proptest::prelude::*;
 use validator::validate_telegram_markdown;
 
-fn arb_dash_boundary() -> impl Strategy<Value = String> {
+fn arb_dash_boundary_short() -> impl Strategy<Value = String> {
     let prefix_re = format!(r"[A-Za-z0-9]{{{}}}", TELEGRAM_LIMIT - 1);
     proptest::string::string_regex(&prefix_re)
         .unwrap()
@@ -64,11 +64,10 @@ proptest! {
     }
 }
 
-
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(16))]
     #[test]
-    fn dash_boundary_preserves_escape(text in arb_dash_boundary()) {
+    fn dash_boundary_preserves_escape(text in arb_dash_boundary_short()) {
         let posts = split_posts(&text, TELEGRAM_LIMIT);
         prop_assert!(!posts.is_empty());
     }


### PR DESCRIPTION
## Summary
- fix duplicate `arb_dash_boundary` by renaming the first helper

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6869387778dc8332acef5aca367d535b