### PR TITLE
Update README for toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ This repository contains a small tool and workflow for sending summaries of the 
 The GitHub Actions workflow checks out the [`rust-lang/this-week-in-rust`](https://github.com/rust-lang/this-week-in-rust) repository and detects the newest Markdown file in its `content` directory. If a new issue is found, it is parsed with the Rust application in `src/main.rs`, and the generated message is posted to the configured Telegram chat. Each section becomes an individual Telegram post, and sections or overly long lines exceeding Telegram's size limit are automatically split.
 The parser now derives the HTML link from the issue number and date and appends it at the end of each Telegram message.
 
+## Toolchain
+
+The project requires **Rust 1.88.0** and `rustfmt` **1.8.0**. The `rust-toolchain.toml` file pins the channel and lists the mandatory `clippy` and `rustfmt` components so `rustup` always uses the correct versions. If these components are not installed automatically, run:
+
+```bash
+rustup component add clippy rustfmt
+```
+
 To run the workflow locally you must clone the `this-week-in-rust` repository into a `twir` subdirectory:
 
 ```bash

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -12,17 +12,6 @@ use generator::{TELEGRAM_LIMIT, split_posts};
 use proptest::prelude::*;
 use validator::validate_telegram_markdown;
 
-fn arb_dash_boundary() -> impl Strategy<Value = String> {
-    let prefix_re = format!(r"[A-Za-z0-9]{{{}}}", TELEGRAM_LIMIT - 1);
-    proptest::string::string_regex(&prefix_re)
-        .unwrap()
-        .prop_flat_map(|pre| {
-            proptest::string::string_regex("[A-Za-z0-9]{0,10}")
-                .unwrap()
-                .prop_map(move |post| format!("{pre}\\-{post}"))
-        })
-}
-
 fn arb_long_line() -> impl Strategy<Value = String> {
     let regex = format!(
         r"[A-Za-z0-9\\*_]{{{},{}}}",
@@ -63,7 +52,6 @@ proptest! {
         }
     }
 }
-
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(16))]


### PR DESCRIPTION
## Summary
- document required Rust version and rustfmt version
- remove duplicate `arb_dash_boundary` test helper

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6869387629888332ae27ee02aab0fb61