### PR TITLE
Add rustfmt configuration file

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+required_version = "1.8.0"
+edition = "2024"
+

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -64,7 +64,6 @@ proptest! {
     }
 }
 
-
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(16))]
     #[test]
@@ -72,17 +71,6 @@ proptest! {
         let posts = split_posts(&text, TELEGRAM_LIMIT);
         prop_assert!(!posts.is_empty());
     }
-}
-
-fn arb_dash_boundary() -> impl Strategy<Value = String> {
-    let prefix_regex = format!(r"[A-Za-z0-9]{{{}}}", TELEGRAM_LIMIT - 1);
-    proptest::string::string_regex(&prefix_regex)
-        .unwrap()
-        .prop_flat_map(|prefix| {
-            proptest::string::string_regex("[A-Za-z0-9]{0,20}")
-                .unwrap()
-                .prop_map(move |suffix| format!("{prefix}\\-{suffix}"))
-        })
 }
 
 proptest! {


### PR DESCRIPTION
## Summary
- introduce `.rustfmt.toml` specifying required rustfmt version and edition
- remove duplicate `arb_dash_boundary` helper from tests

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869387754d08332912542e23c14695a