### PR TITLE
Specify rustfmt config and pin toolchain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
           profile: minimal
 
       - name: Send latest post to Telegram

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo fmt --quiet --all -- --check
 
   check:
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo check --quiet --all-targets --features integration
 
   clippy:
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo clippy --quiet --all-targets --features integration -- -D warnings
 
   test:
@@ -51,5 +51,5 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo test --quiet --all-targets --features integration -- --test-threads=$(nproc)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo fmt --quiet --all -- --check
 
   check:
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo check --quiet --all-targets --all-features
 
   clippy:
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo clippy --quiet --all-targets --all-features -- -D warnings
 
   test:
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo test --quiet --all-targets --all-features -- --test-threads=$(nproc)
 
   machete:
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo install cargo-machete --quiet
       - run: cargo machete
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo run --quiet --bin check-docs
 
   coverage:
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
+          toolchain: "1.88.0"
       - run: cargo install cargo-tarpaulin --quiet
       - run: cargo tarpaulin --out Lcov --output-dir coverage -- --quiet
       - uses: actions/upload-artifact@v4

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2024"
+max_width = 100
+newline_style = "Unix"
+use_small_heuristics = "Default"

--- a/tests/cfp_regression.rs
+++ b/tests/cfp_regression.rs
@@ -46,7 +46,7 @@ If you are an event organizer hoping to expand the reach of your event, please s
 #[test]
 fn cfp_section_generates_valid_markdown() {
     let input = format!("Title: Test\nNumber: 1\nDate: 2025-06-25\n\n{CFP_SNIPPET}");
-    let posts = generate_posts(input);
+    let posts = generate_posts(input).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         validate_telegram_markdown(post)

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -73,17 +73,6 @@ proptest! {
     }
 }
 
-fn arb_dash_boundary() -> impl Strategy<Value = String> {
-    let prefix_regex = format!(r"[A-Za-z0-9]{{{}}}", TELEGRAM_LIMIT - 1);
-    proptest::string::string_regex(&prefix_regex)
-        .unwrap()
-        .prop_flat_map(|prefix| {
-            proptest::string::string_regex("[A-Za-z0-9]{0,20}")
-                .unwrap()
-                .prop_map(move |suffix| format!("{prefix}\\-{suffix}"))
-        })
-}
-
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(16))]
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -84,20 +84,9 @@ fn parse_issue_606_full() {
 }
 
 #[test]
-fn parse_call_for_participation() {
-    let input = include_str!("2025-07-05-call-for-participation.md");
-    let posts = generate_posts(input.to_string());
-
-    let expected = [
-        include_str!("expected/cfp1.md"),
-        include_str!("expected/cfp2.md"),
-  ];
-}
-
-#[test]    
 fn parse_issue_607_full() {
     let input = include_str!("2025-07-05-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/607_1.md"),
@@ -199,7 +188,7 @@ fn send_long_escaped_dash() {
 #[test]
 fn issue_606_no_unescaped_dashes() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
     for (i, post) in posts.iter().enumerate() {
         assert!(
@@ -213,7 +202,7 @@ fn issue_606_no_unescaped_dashes() {
 #[test]
 fn parse_call_for_participation() {
     let input = include_str!("2025-07-05-call-for-participation.md");
-    let posts = generate_posts(input.to_string());
+    let posts = generate_posts(input.to_string()).unwrap();
 
     let expected = [
         include_str!("expected/cfp1.md"),


### PR DESCRIPTION
## Summary
- add `.rustfmt.toml` with style options
- pin CI workflows to toolchain version 1.88.0
- fix tests after unwrapping results and remove duplicate functions

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686935811fd8833287d8f688b6fd37df