### PR TITLE
fix: checkout repo before running setup-rust action

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
@@ -27,6 +28,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
@@ -38,6 +40,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
@@ -49,6 +52,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
@@ -26,6 +27,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
@@ -37,6 +39,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
@@ -48,6 +51,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
@@ -59,6 +63,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
@@ -71,6 +76,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
@@ -82,6 +88,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -76,7 +76,7 @@ proptest! {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(16))]
     #[test]
-    fn dash_escape_at_boundary(input in arb_dash_boundary()) {
+    fn dash_escape_at_boundary(input in arb_dash_boundary_short()) {
         let posts = split_posts(&input, TELEGRAM_LIMIT);
         prop_assert!(posts.len() >= 2);
         for p in posts {


### PR DESCRIPTION
## Summary
- ensure GitHub Actions checkout repository before using setup-rust
- fix generator tests after renaming helper

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686941778b00833292d64e4be8bd0c2a