### PR TITLE
Add delay between Telegram posts

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -3,13 +3,14 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use reqwest::blocking::Client;
 use serde::Deserialize;
-use std::{fs, path::Path};
+use std::{fs, path::Path, thread, time::Duration};
 use teloxide::utils::markdown::{escape, escape_link_url};
 
 use crate::parser::{Section, parse_sections};
 use crate::validator::validate_telegram_markdown;
 
 pub const TELEGRAM_LIMIT: usize = 4000;
+pub const TELEGRAM_DELAY_MS: u64 = 500;
 
 static LINK_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap());
 
@@ -318,6 +319,7 @@ pub fn send_to_telegram(
             )
             .into());
         }
+        thread::sleep(Duration::from_millis(TELEGRAM_DELAY_MS));
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add 500ms delay after each successful message in `send_to_telegram`
- expose delay as `TELEGRAM_DELAY_MS`
- import `thread` and `Duration`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68694e42a1d8833290a5fde39f7b52ae