### PR TITLE
Add post index logging for Telegram errors

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -308,12 +308,14 @@ pub fn send_to_telegram(
             .map_err(|e| format!("Failed to parse Telegram response: {e}: {body}"))?;
         if !data.ok {
             error!(
-                "Telegram error {}: {}",
+                "Telegram error for post {} {}: {}",
+                i + 1,
                 data.error_code.unwrap_or_default(),
                 data.description.as_deref().unwrap_or("unknown")
             );
             return Err(format!(
-                "Telegram API error {}: {}",
+                "Telegram API error in post {} {}: {}",
+                i + 1,
                 data.error_code.unwrap_or_default(),
                 data.description.unwrap_or_default()
             )


### PR DESCRIPTION
## Summary
- log the current post number when Telegram API errors occur
- include the post index in the returned error message

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_68695336dd88833283827d74c65d89d2