### PR TITLE
Add markdown assertion helper for tests

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -328,6 +328,10 @@ pub fn send_to_telegram(
 mod tests {
     use super::*;
     use crate::parser::parse_sections;
+    mod common {
+        include!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/common/mod.rs"));
+    }
+    use common::assert_valid_markdown;
     use std::fs;
 
     #[test]
@@ -450,7 +454,7 @@ mod tests {
         )
         .unwrap();
         for p in posts {
-            crate::validator::validate_telegram_markdown(&p).unwrap();
+            assert_valid_markdown(&p);
         }
     }
 
@@ -463,7 +467,7 @@ mod tests {
         assert!(parts.len() > 1);
         assert!(parts[1].starts_with("\\-"));
         for p in parts {
-            crate::validator::validate_telegram_markdown(&p).unwrap();
+            assert_valid_markdown(&p);
         }
     }
 
@@ -477,13 +481,13 @@ mod tests {
         assert!(parts.len() > 1);
         assert!(parts[1].starts_with("\\-"));
         for p in parts {
-            crate::validator::validate_telegram_markdown(&p).unwrap();
+            assert_valid_markdown(&p);
         }
     }
 
     #[test]
     fn markdown_validation() {
-        assert!(crate::validator::validate_telegram_markdown("simple text").is_ok());
+        assert_valid_markdown("simple text");
         assert!(crate::validator::validate_telegram_markdown("bad *text").is_err());
     }
 

--- a/tests/cfp_regression.rs
+++ b/tests/cfp_regression.rs
@@ -1,3 +1,4 @@
+mod common;
 #[allow(dead_code)]
 #[path = "../src/generator.rs"]
 mod generator;
@@ -8,8 +9,8 @@ mod parser;
 #[path = "../src/validator.rs"]
 mod validator;
 
+use common::assert_valid_markdown;
 use generator::generate_posts;
-use validator::validate_telegram_markdown;
 
 const CFP_SNIPPET: &str = r#"## Call for Participation; projects and speakers
 
@@ -48,8 +49,7 @@ fn cfp_section_generates_valid_markdown() {
     let input = format!("Title: Test\nNumber: 1\nDate: 2025-06-25\n\n{CFP_SNIPPET}");
     let posts = generate_posts(input).unwrap();
     assert!(!posts.is_empty());
-    for (i, post) in posts.iter().enumerate() {
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for post in &posts {
+        assert_valid_markdown(post);
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,5 @@
+/// Helper that panics if the provided Telegram Markdown is invalid.
+pub fn assert_valid_markdown(post: &str) {
+    crate::validator::validate_telegram_markdown(post)
+        .unwrap_or_else(|e| panic!("invalid Telegram Markdown: {e}"));
+}

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -1,3 +1,4 @@
+mod common;
 #[allow(dead_code)]
 #[path = "../src/generator.rs"]
 mod generator;
@@ -8,9 +9,9 @@ mod parser;
 #[path = "../src/validator.rs"]
 mod validator;
 
+use common::assert_valid_markdown;
 use generator::{TELEGRAM_LIMIT, split_posts};
 use proptest::prelude::*;
-use validator::validate_telegram_markdown;
 
 fn arb_dash_boundary_short() -> impl Strategy<Value = String> {
     let prefix_re = format!(r"[A-Za-z0-9]{{{}}}", TELEGRAM_LIMIT - 1);
@@ -59,7 +60,7 @@ proptest! {
         let posts = split_posts(&line, TELEGRAM_LIMIT);
         prop_assert!(!posts.is_empty());
         for p in posts {
-            prop_assert!(validate_telegram_markdown(&p).is_ok());
+            assert_valid_markdown(&p);
         }
     }
 }
@@ -81,7 +82,7 @@ proptest! {
         prop_assert!(posts.len() >= 2);
         for p in posts {
             prop_assert!(!p.starts_with('-'));
-            prop_assert!(validate_telegram_markdown(&p).is_ok());
+            assert_valid_markdown(&p);
         }
     }
 }
@@ -95,6 +96,6 @@ fn boundary_escape_preserved() {
     assert!(posts.len() >= 2);
     assert!(!posts[1].starts_with('-'));
     for p in posts {
-        validate_telegram_markdown(&p).unwrap();
+        assert_valid_markdown(&p);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 
 #[cfg(feature = "integration")]
 use mockito::Matcher;
+mod common;
 #[allow(dead_code)]
 #[path = "../src/generator.rs"]
 mod generator;
@@ -13,7 +14,7 @@ mod parser;
 #[path = "../src/validator.rs"]
 mod validator;
 
-use validator::validate_telegram_markdown;
+use common::assert_valid_markdown;
 
 #[test]
 fn crate_of_the_week_is_preserved() {
@@ -32,7 +33,7 @@ fn crate_of_the_week_is_preserved() {
     let output = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
     assert!(output.contains("📰 **CRATE OF THE WEEK**"));
     assert!(output.contains("primitive\\_fixed\\_point\\_decimal"));
-    validate_telegram_markdown(&output).unwrap();
+    assert_valid_markdown(&output);
 }
 
 #[test]
@@ -54,8 +55,8 @@ fn crate_of_week_followed_by_section() {
     assert!(first.contains("📰 **CRATE OF THE WEEK**"));
     assert!(first.contains("[demo](https://example.com)"));
     assert!(second.contains("📰 **NEXT**"));
-    validate_telegram_markdown(&first).unwrap();
-    validate_telegram_markdown(&second).unwrap();
+    assert_valid_markdown(&first);
+    assert_valid_markdown(&second);
 }
 
 #[cfg(feature = "integration")]
@@ -91,8 +92,8 @@ fn telegram_request_sent() {
     assert!(status.success());
     let post1 = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
     let post2 = fs::read_to_string(dir.path().join("output_2.md")).unwrap();
-    validate_telegram_markdown(&post1).unwrap();
-    validate_telegram_markdown(&post2).unwrap();
+    assert_valid_markdown(&post1);
+    assert_valid_markdown(&post2);
     m.assert();
 }
 
@@ -205,8 +206,8 @@ fn sends_valid_markdown() {
     assert!(status.success());
     let post1 = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
     let post2 = fs::read_to_string(dir.path().join("output_2.md")).unwrap();
-    validate_telegram_markdown(&post1).unwrap();
-    validate_telegram_markdown(&post2).unwrap();
+    assert_valid_markdown(&post1);
+    assert_valid_markdown(&post2);
     m.assert();
 }
 
@@ -250,7 +251,7 @@ fn full_issue_end_to_end() {
 
     for i in 1..=8 {
         let post = fs::read_to_string(dir.path().join(format!("output_{i}.md"))).unwrap();
-        validate_telegram_markdown(&post).unwrap();
+        assert_valid_markdown(&post);
     }
     for m in mocks {
         m.assert();
@@ -280,5 +281,5 @@ fn send_issue_606_post_4() {
 
     generator::send_to_telegram(&[posts[3].clone()], &server.url(), "TEST", "42", true).unwrap();
     m.assert();
-    validate_telegram_markdown(&posts[3]).unwrap();
+    assert_valid_markdown(&posts[3]);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,4 @@
+mod common;
 #[allow(dead_code)]
 #[path = "../src/generator.rs"]
 mod generator;
@@ -8,9 +9,9 @@ mod parser;
 #[path = "../src/validator.rs"]
 mod validator;
 
+use common::assert_valid_markdown;
 use generator::generate_posts;
 use generator::send_to_telegram;
-use validator::validate_telegram_markdown;
 
 #[test]
 fn parse_latest_issue_full() {
@@ -105,8 +106,7 @@ fn parse_issue_607_full() {
     assert_eq!(posts.len(), expected.len(), "post count mismatch");
     for (i, (post, exp)) in posts.iter().zip(expected.iter()).enumerate() {
         assert_eq!(post, exp, "Mismatch in post {}", i + 1);
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+        assert_valid_markdown(post);
     }
 }
 
@@ -115,9 +115,8 @@ fn validate_generated_posts() {
     let input = include_str!("2025-06-25-this-week-in-rust.md");
     let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
-    for (i, post) in posts.iter().enumerate() {
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for post in &posts {
+        assert_valid_markdown(post);
     }
 }
 
@@ -126,9 +125,8 @@ fn validate_issue_606_posts() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
     let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
-    for (i, post) in posts.iter().enumerate() {
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for post in &posts {
+        assert_valid_markdown(post);
     }
 }
 
@@ -137,7 +135,7 @@ fn validate_issue_606_post_4() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
     let posts = generate_posts(input.to_string()).unwrap();
     assert!(posts.len() >= 4);
-    validate_telegram_markdown(&posts[3]).unwrap();
+    assert_valid_markdown(&posts[3]);
 }
 
 #[test]
@@ -145,9 +143,8 @@ fn validate_complex_posts() {
     let input = include_str!("complex.md");
     let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
-    for (i, post) in posts.iter().enumerate() {
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for post in &posts {
+        assert_valid_markdown(post);
     }
 }
 
@@ -212,7 +209,6 @@ fn parse_call_for_participation() {
     assert_eq!(posts.len(), expected.len(), "post count mismatch");
     for (i, (post, exp)) in posts.iter().zip(expected.iter()).enumerate() {
         assert_eq!(post, exp, "Mismatch in post {}", i + 1);
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+        assert_valid_markdown(post);
     }
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,3 +1,4 @@
+mod common;
 #[allow(dead_code)]
 #[path = "../src/generator.rs"]
 mod generator;
@@ -8,6 +9,7 @@ mod parser;
 #[path = "../src/validator.rs"]
 mod validator;
 
+use common::assert_valid_markdown;
 use parser::parse_sections;
 
 #[test]
@@ -29,5 +31,5 @@ fn bare_link_with_parentheses() {
         sections[0].lines,
         vec!["• [Some text](https://example.com/path(1\\))"]
     );
-    validator::validate_telegram_markdown(&sections[0].lines[0]).unwrap();
+    assert_valid_markdown(&sections[0].lines[0]);
 }

--- a/tests/telegram_e2e.rs
+++ b/tests/telegram_e2e.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "integration")]
 
+mod common;
 #[allow(dead_code)]
 #[path = "../src/generator.rs"]
 mod generator;
@@ -10,11 +11,11 @@ mod parser;
 #[path = "../src/validator.rs"]
 mod validator;
 
+use common::assert_valid_markdown;
 use generator::{generate_posts, send_to_telegram};
 use reqwest::blocking::Client;
 use serde_json::Value;
 use std::env;
-use validator::validate_telegram_markdown;
 
 #[test]
 fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -51,8 +52,8 @@ fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 
     let input = include_str!("2025-06-25-this-week-in-rust.md");
     let posts = generate_posts(input.to_string()).unwrap();
-    for (i, p) in posts.iter().enumerate() {
-        validate_telegram_markdown(p).unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for p in &posts {
+        assert_valid_markdown(p);
     }
     send_to_telegram(&posts, &base, &token, &chat_id, true)?;
 


### PR DESCRIPTION
## Summary
- introduce `assert_valid_markdown` helper under `tests/common`
- use the new helper across test modules

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869543a2490833297e138703e571357