### PR TITLE
Add docs for public functions

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,11 @@ struct Cli {
     plain: bool,
 }
 
+/// Entry point for the command-line interface.
+///
+/// Reads the provided Markdown file, generates Telegram posts, optionally
+/// converts them to plain text and sends them to Telegram if credentials are
+/// set.
 pub fn main() -> std::io::Result<()> {
     env_logger::init();
     let cli = Cli::parse();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,7 +28,13 @@ fn fix_bare_link(line: &str) -> String {
     }
 }
 
-/// Parse TWIR Markdown into sections using `pulldown-cmark`.
+/// Parse TWIR Markdown into logical sections using `pulldown-cmark`.
+///
+/// # Parameters
+/// - `text`: Full Markdown source from a TWIR issue.
+///
+/// # Returns
+/// A list of [`Section`]s preserving the order found in the input.
 pub fn parse_sections(text: &str) -> Vec<Section> {
     let mut sections = Vec::new();
     let mut current: Option<Section> = None;

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,8 +1,15 @@
 use std::collections::VecDeque;
 
-/// Validate that the provided text conforms to Telegram Markdown v2 rules
-/// used in this project. Returns `Ok(())` if valid, otherwise an error
-/// message describing the first encountered problem.
+/// Validate that the provided text conforms to the Telegram Markdown V2 rules
+/// used in this project.
+///
+/// # Parameters
+/// - `text`: Telegram-formatted Markdown to validate.
+///
+/// # Returns
+/// - `Ok(())` if the text is valid.
+/// - `Err(String)` with a description of the first encountered problem
+///   otherwise.
 pub fn validate_telegram_markdown(text: &str) -> Result<(), String> {
     let chars: Vec<char> = text.chars().collect();
     let mut stack: VecDeque<&str> = VecDeque::new();


### PR DESCRIPTION
## Summary
- document all public functions in generator.rs, parser.rs, validator.rs and cli.rs

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68695437483483328ca4afc88e723a42