### PR TITLE
Implement retry logic for Telegram requests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -67,7 +67,7 @@ fn telegram_request_sent() {
     fs::write(&input_path, input).unwrap();
 
     let mut server = mockito::Server::new();
-    let m = server
+    let success = server
         .mock("POST", "/botTEST/sendMessage")
         .match_header("content-type", "application/x-www-form-urlencoded")
         .match_body(Matcher::AllOf(vec![
@@ -78,6 +78,13 @@ fn telegram_request_sent() {
         .with_status(200)
         .with_body("{\"ok\":true}")
         .expect(2)
+        .create();
+
+    let fail = server
+        .mock("POST", "/botTEST/sendMessage")
+        .with_status(503)
+        .with_body("{\"ok\":false}")
+        .expect(1)
         .create();
 
     let status = Command::new(env!("CARGO_BIN_EXE_twir-deploy-notify"))
@@ -93,7 +100,8 @@ fn telegram_request_sent() {
     let post2 = fs::read_to_string(dir.path().join("output_2.md")).unwrap();
     validate_telegram_markdown(&post1).unwrap();
     validate_telegram_markdown(&post2).unwrap();
-    m.assert();
+    success.assert();
+    fail.assert();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- retry Telegram requests with a backoff delay
- log failed attempts
- update integration test to expect retry behaviour

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869543595c883329a5842efdffae03a