### PR TITLE
Add library crate and update tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ proptest = "1"
 [features]
 integration = []
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 name = "check-docs"
 path = "src/bin/check_docs.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod cli;
+pub mod generator;
+pub mod parser;
+pub mod validator;

--- a/tests/cfp_regression.rs
+++ b/tests/cfp_regression.rs
@@ -1,12 +1,5 @@
-#[allow(dead_code)]
-#[path = "../src/generator.rs"]
-mod generator;
-#[allow(dead_code)]
-#[path = "../src/parser.rs"]
-mod parser;
-#[allow(dead_code)]
-#[path = "../src/validator.rs"]
-mod validator;
+#[allow(unused_imports)]
+use twir_deploy_notify::{generator, parser, validator};
 
 use generator::generate_posts;
 use validator::validate_telegram_markdown;

--- a/tests/dash_regression.rs
+++ b/tests/dash_regression.rs
@@ -1,12 +1,5 @@
-#[allow(dead_code)]
-#[path = "../src/generator.rs"]
-mod generator;
-#[allow(dead_code)]
-#[path = "../src/parser.rs"]
-mod parser;
-#[allow(dead_code)]
-#[path = "../src/validator.rs"]
-mod validator;
+#[allow(unused_imports)]
+use twir_deploy_notify::{generator, parser, validator};
 
 use generator::generate_posts;
 use validator::validate_telegram_markdown;

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -1,12 +1,5 @@
-#[allow(dead_code)]
-#[path = "../src/generator.rs"]
-mod generator;
-#[allow(dead_code)]
-#[path = "../src/parser.rs"]
-mod parser;
-#[allow(dead_code)]
-#[path = "../src/validator.rs"]
-mod validator;
+#[allow(unused_imports)]
+use twir_deploy_notify::{generator, parser, validator};
 
 use generator::{TELEGRAM_LIMIT, split_posts};
 use proptest::prelude::*;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,17 +1,10 @@
+#[allow(unused_imports)]
+use twir_deploy_notify::{generator, parser, validator};
 use std::fs;
 use std::process::Command;
 
 #[cfg(feature = "integration")]
 use mockito::Matcher;
-#[allow(dead_code)]
-#[path = "../src/generator.rs"]
-mod generator;
-#[allow(dead_code)]
-#[path = "../src/parser.rs"]
-mod parser;
-#[allow(dead_code)]
-#[path = "../src/validator.rs"]
-mod validator;
 
 use validator::validate_telegram_markdown;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,12 +1,5 @@
-#[allow(dead_code)]
-#[path = "../src/generator.rs"]
-mod generator;
-#[allow(dead_code)]
-#[path = "../src/parser.rs"]
-mod parser;
-#[allow(dead_code)]
-#[path = "../src/validator.rs"]
-mod validator;
+#[allow(unused_imports)]
+use twir_deploy_notify::{generator, parser, validator};
 
 use generator::generate_posts;
 use generator::send_to_telegram;

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,12 +1,5 @@
-#[allow(dead_code)]
-#[path = "../src/generator.rs"]
-mod generator;
-#[allow(dead_code)]
-#[path = "../src/parser.rs"]
-mod parser;
-#[allow(dead_code)]
-#[path = "../src/validator.rs"]
-mod validator;
+#[allow(unused_imports)]
+use twir_deploy_notify::{generator, parser, validator};
 
 use parser::parse_sections;
 

--- a/tests/telegram_e2e.rs
+++ b/tests/telegram_e2e.rs
@@ -1,14 +1,6 @@
 #![cfg(feature = "integration")]
-
-#[allow(dead_code)]
-#[path = "../src/generator.rs"]
-mod generator;
-#[allow(dead_code)]
-#[path = "../src/parser.rs"]
-mod parser;
-#[allow(dead_code)]
-#[path = "../src/validator.rs"]
-mod validator;
+#[allow(unused_imports)]
+use twir_deploy_notify::{generator, parser, validator};
 
 use generator::{generate_posts, send_to_telegram};
 use reqwest::blocking::Client;


### PR DESCRIPTION
## Summary
- add `src/lib.rs` that re-exports the internal modules
- configure Cargo to use the new library crate
- update tests to use the crate modules directly and drop old path hacks

## Testing
- `cargo machete`
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68695434e0d4833298faaa2649d1d939