### PR TITLE
Fix dash handling in validator

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -81,7 +81,11 @@ pub fn validate_telegram_markdown(text: &str) -> Result<(), String> {
             }
             '-' | '>' | '#' | '+' | '=' | '{' | '}' | '.' | '!' => {
                 let prev = if i == 0 { None } else { Some(chars[i - 1]) };
-                if prev != Some('\\') {
+                let next = chars.get(i + 1).copied();
+                if prev != Some('\\')
+                    && !(prev.map(|c| c.is_ascii_alphanumeric()).unwrap_or(false)
+                        && next.map(|c| c.is_ascii_alphanumeric()).unwrap_or(false))
+                {
                     return Err(format!("Unescaped {ch} at {i}"));
                 }
             }

--- a/tests/dash_regression2.rs
+++ b/tests/dash_regression2.rs
@@ -1,0 +1,30 @@
+#[allow(dead_code)]
+#[path = "../src/validator.rs"]
+mod validator;
+
+use validator::validate_telegram_markdown;
+
+const MSG: &str = r"*Часть 4/11*
+📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS**
+**CFP \- Projects**
+Always wanted to contribute to open-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
+Some of these tasks may also have mentors available, visit the task page for more information\.
+No Calls for participation were submitted this week\.
+If you are a Rust project owner and are looking for contributors, please submit tasks [here](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines) or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
+**CFP \- Events**
+Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker\.
+No Calls for papers or presentations were submitted this week\.
+If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!";
+
+#[test]
+fn raw_fourth_message_should_be_valid() {
+    assert!(validate_telegram_markdown(MSG).is_ok());
+}
+
+#[test]
+fn raw_fourth_message_debug() {
+    match validate_telegram_markdown(MSG) {
+        Ok(_) => println!("ok"),
+        Err(e) => println!("err: {e}"),
+    }
+}

--- a/tests/dash_word.rs
+++ b/tests/dash_word.rs
@@ -1,0 +1,11 @@
+#[allow(dead_code)]
+#[path = "../src/validator.rs"]
+mod validator;
+use validator::validate_telegram_markdown;
+
+#[test]
+fn dash_inside_word_is_ok() {
+    let msg =
+        "Always wanted to contribute to open-source projects but did not know where to start?";
+    assert!(validate_telegram_markdown(msg).is_ok());
+}


### PR DESCRIPTION
## Summary
- handle dashes inside words in `validate_telegram_markdown`
- add regression tests for dash validation

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete` *(fails: `no such command: machete`)*

------
https://chatgpt.com/codex/tasks/task_e_68695339bf8883329fe873bea5a8e715