### PR TITLE
Добавлен хелпер assert_valid_markdown

### DIFF
--- a/tests/cfp_regression.rs
+++ b/tests/cfp_regression.rs
@@ -1,8 +1,7 @@
-#[allow(unused_imports)]
-use twir_deploy_notify::{generator, parser, validator};
+use twir_deploy_notify::generator;
 
 use generator::generate_posts;
-use validator::validate_telegram_markdown;
+mod common;
 
 const CFP_SNIPPET: &str = r#"## Call for Participation; projects and speakers
 
@@ -41,8 +40,7 @@ fn cfp_section_generates_valid_markdown() {
     let input = format!("Title: Test\nNumber: 1\nDate: 2025-06-25\n\n{CFP_SNIPPET}");
     let posts = generate_posts(input).unwrap();
     assert!(!posts.is_empty());
-    for (i, post) in posts.iter().enumerate() {
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for post in &posts {
+        common::assert_valid_markdown(post);
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,4 @@
+pub fn assert_valid_markdown(post: &str) {
+    twir_deploy_notify::validator::validate_telegram_markdown(post)
+        .unwrap_or_else(|e| panic!("invalid telegram markdown: {e}"));
+}

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -1,9 +1,8 @@
-#[allow(unused_imports)]
-use twir_deploy_notify::{generator, parser, validator};
+use twir_deploy_notify::generator;
 
 use generator::{TELEGRAM_LIMIT, split_posts};
 use proptest::prelude::*;
-use validator::validate_telegram_markdown;
+mod common;
 
 fn arb_dash_boundary_short() -> impl Strategy<Value = String> {
     let prefix_re = format!(r"[A-Za-z0-9]{{{}}}", TELEGRAM_LIMIT - 1);
@@ -52,7 +51,7 @@ proptest! {
         let posts = split_posts(&line, TELEGRAM_LIMIT);
         prop_assert!(!posts.is_empty());
         for p in posts {
-            prop_assert!(validate_telegram_markdown(&p).is_ok());
+            common::assert_valid_markdown(&p);
         }
     }
 }
@@ -74,7 +73,7 @@ proptest! {
         prop_assert!(posts.len() >= 2);
         for p in posts {
             prop_assert!(!p.starts_with('-'));
-            prop_assert!(validate_telegram_markdown(&p).is_ok());
+            common::assert_valid_markdown(&p);
         }
     }
 }
@@ -88,6 +87,6 @@ fn boundary_escape_preserved() {
     assert!(posts.len() >= 2);
     assert!(!posts[1].starts_with('-'));
     for p in posts {
-        validate_telegram_markdown(&p).unwrap();
+        common::assert_valid_markdown(&p);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,12 +1,11 @@
-#[allow(unused_imports)]
-use twir_deploy_notify::{generator, parser, validator};
 use std::fs;
 use std::process::Command;
+use twir_deploy_notify::generator;
 
 #[cfg(feature = "integration")]
 use mockito::Matcher;
 
-use validator::validate_telegram_markdown;
+mod common;
 
 #[test]
 fn crate_of_the_week_is_preserved() {
@@ -25,7 +24,7 @@ fn crate_of_the_week_is_preserved() {
     let output = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
     assert!(output.contains("📰 **CRATE OF THE WEEK**"));
     assert!(output.contains("primitive\\_fixed\\_point\\_decimal"));
-    validate_telegram_markdown(&output).unwrap();
+    common::assert_valid_markdown(&output);
 }
 
 #[test]
@@ -47,8 +46,8 @@ fn crate_of_week_followed_by_section() {
     assert!(first.contains("📰 **CRATE OF THE WEEK**"));
     assert!(first.contains("[demo](https://example.com)"));
     assert!(second.contains("📰 **NEXT**"));
-    validate_telegram_markdown(&first).unwrap();
-    validate_telegram_markdown(&second).unwrap();
+    common::assert_valid_markdown(&first);
+    common::assert_valid_markdown(&second);
 }
 
 #[cfg(feature = "integration")]
@@ -84,8 +83,8 @@ fn telegram_request_sent() {
     assert!(status.success());
     let post1 = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
     let post2 = fs::read_to_string(dir.path().join("output_2.md")).unwrap();
-    validate_telegram_markdown(&post1).unwrap();
-    validate_telegram_markdown(&post2).unwrap();
+    common::assert_valid_markdown(&post1);
+    common::assert_valid_markdown(&post2);
     m.assert();
 }
 
@@ -198,8 +197,8 @@ fn sends_valid_markdown() {
     assert!(status.success());
     let post1 = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
     let post2 = fs::read_to_string(dir.path().join("output_2.md")).unwrap();
-    validate_telegram_markdown(&post1).unwrap();
-    validate_telegram_markdown(&post2).unwrap();
+    common::assert_valid_markdown(&post1);
+    common::assert_valid_markdown(&post2);
     m.assert();
 }
 
@@ -243,7 +242,7 @@ fn full_issue_end_to_end() {
 
     for i in 1..=8 {
         let post = fs::read_to_string(dir.path().join(format!("output_{i}.md"))).unwrap();
-        validate_telegram_markdown(&post).unwrap();
+        common::assert_valid_markdown(&post);
     }
     for m in mocks {
         m.assert();
@@ -273,5 +272,5 @@ fn send_issue_606_post_4() {
 
     generator::send_to_telegram(&[posts[3].clone()], &server.url(), "TEST", "42", true).unwrap();
     m.assert();
-    validate_telegram_markdown(&posts[3]).unwrap();
+    common::assert_valid_markdown(&posts[3]);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,9 +1,8 @@
-#[allow(unused_imports)]
-use twir_deploy_notify::{generator, parser, validator};
+use twir_deploy_notify::generator;
 
 use generator::generate_posts;
 use generator::send_to_telegram;
-use validator::validate_telegram_markdown;
+mod common;
 
 #[test]
 fn parse_latest_issue_full() {
@@ -98,8 +97,7 @@ fn parse_issue_607_full() {
     assert_eq!(posts.len(), expected.len(), "post count mismatch");
     for (i, (post, exp)) in posts.iter().zip(expected.iter()).enumerate() {
         assert_eq!(post, exp, "Mismatch in post {}", i + 1);
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+        common::assert_valid_markdown(post);
     }
 }
 
@@ -108,9 +106,8 @@ fn validate_generated_posts() {
     let input = include_str!("2025-06-25-this-week-in-rust.md");
     let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
-    for (i, post) in posts.iter().enumerate() {
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for post in &posts {
+        common::assert_valid_markdown(post);
     }
 }
 
@@ -119,9 +116,8 @@ fn validate_issue_606_posts() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
     let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
-    for (i, post) in posts.iter().enumerate() {
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for post in &posts {
+        common::assert_valid_markdown(post);
     }
 }
 
@@ -130,7 +126,7 @@ fn validate_issue_606_post_4() {
     let input = include_str!("2025-07-02-this-week-in-rust.md");
     let posts = generate_posts(input.to_string()).unwrap();
     assert!(posts.len() >= 4);
-    validate_telegram_markdown(&posts[3]).unwrap();
+    common::assert_valid_markdown(&posts[3]);
 }
 
 #[test]
@@ -138,9 +134,8 @@ fn validate_complex_posts() {
     let input = include_str!("complex.md");
     let posts = generate_posts(input.to_string()).unwrap();
     assert!(!posts.is_empty());
-    for (i, post) in posts.iter().enumerate() {
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for post in &posts {
+        common::assert_valid_markdown(post);
     }
 }
 
@@ -205,7 +200,6 @@ fn parse_call_for_participation() {
     assert_eq!(posts.len(), expected.len(), "post count mismatch");
     for (i, (post, exp)) in posts.iter().zip(expected.iter()).enumerate() {
         assert_eq!(post, exp, "Mismatch in post {}", i + 1);
-        validate_telegram_markdown(post)
-            .unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+        common::assert_valid_markdown(post);
     }
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,7 +1,7 @@
-#[allow(unused_imports)]
-use twir_deploy_notify::{generator, parser, validator};
+use twir_deploy_notify::parser;
 
 use parser::parse_sections;
+mod common;
 
 #[test]
 fn code_block_before_next_heading() {
@@ -22,5 +22,5 @@ fn bare_link_with_parentheses() {
         sections[0].lines,
         vec!["• [Some text](https://example.com/path(1\\))"]
     );
-    validator::validate_telegram_markdown(&sections[0].lines[0]).unwrap();
+    common::assert_valid_markdown(&sections[0].lines[0]);
 }

--- a/tests/telegram_e2e.rs
+++ b/tests/telegram_e2e.rs
@@ -1,12 +1,11 @@
 #![cfg(feature = "integration")]
-#[allow(unused_imports)]
-use twir_deploy_notify::{generator, parser, validator};
+use twir_deploy_notify::generator;
 
 use generator::{generate_posts, send_to_telegram};
 use reqwest::blocking::Client;
 use serde_json::Value;
 use std::env;
-use validator::validate_telegram_markdown;
+mod common;
 
 #[test]
 fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -43,8 +42,8 @@ fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 
     let input = include_str!("2025-06-25-this-week-in-rust.md");
     let posts = generate_posts(input.to_string()).unwrap();
-    for (i, p) in posts.iter().enumerate() {
-        validate_telegram_markdown(p).unwrap_or_else(|e| panic!("post {} invalid: {}", i + 1, e));
+    for p in &posts {
+        common::assert_valid_markdown(p);
     }
     send_to_telegram(&posts, &base, &token, &chat_id, true)?;
 


### PR DESCRIPTION
## Summary
- создали модуль `tests/common.rs` с функцией `assert_valid_markdown`
- заменили повторяющиеся вызовы `validate_telegram_markdown` в тестах на хелпер
- почистили импорты и циклы в тестах

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68695eb591e08332a03f6d5bad4e492b