### PR TITLE
Fix formatting

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::process::Command;
+#[cfg(feature = "integration")]
 use twir_deploy_notify::generator;
 
 #[cfg(feature = "integration")]


### PR DESCRIPTION
## Summary
- gate generator import behind `integration` feature so it doesn't raise warnings

## Testing
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686971d1c330833292feda1c59050e00