### PR TITLE
Add env gating for Telegram e2e test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,16 +57,19 @@ jobs:
           toolchain: 1.88.0
       - run: cargo test --quiet --all-targets --all-features -- --test-threads=$(nproc)
 
-  integration-tests:
-    needs: test
-    runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_PROGRESS_WHEN: never
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
-        with:
-          toolchain: 1.88.0
+    integration-tests:
+      needs: test
+      runs-on: ubuntu-latest
+      env:
+        CARGO_TERM_PROGRESS_WHEN: never
+        RUN_TELEGRAM_E2E: ${{ secrets.RUN_TELEGRAM_E2E }}
+        TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      steps:
+        - uses: actions/checkout@v4
+        - uses: ./.github/actions/setup-rust
+          with:
+            toolchain: 1.88.0
       - run: cargo test --quiet --all-targets --features integration -- --test-threads=$(nproc)
 
   machete:

--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ Continuous integration runs `cargo machete` to verify that `Cargo.toml` lists on
 
 Documentation Markdown is validated with `cargo run --bin check-docs`, which parses files using [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark).
 Generated Telegram posts are verified with the shared `validator` module.
+
+## End-to-End Test
+
+The `telegram_e2e` test sends real messages to Telegram. It is skipped unless the
+`RUN_TELEGRAM_E2E` environment variable is present. Provide valid credentials and
+enable the integration feature:
+
+```bash
+RUN_TELEGRAM_E2E=1 TELEGRAM_BOT_TOKEN=<token> TELEGRAM_CHAT_ID=<chat_id> \
+  cargo test --all-targets --features integration
+```

--- a/tests/telegram_e2e.rs
+++ b/tests/telegram_e2e.rs
@@ -9,6 +9,10 @@ mod common;
 
 #[test]
 fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if env::var("RUN_TELEGRAM_E2E").is_err() {
+        eprintln!("Missing RUN_TELEGRAM_E2E, skipping");
+        return Ok(());
+    }
     let token = match env::var("TELEGRAM_BOT_TOKEN") {
         Ok(v) => v,
         Err(_) => {


### PR DESCRIPTION
## Summary
- skip telegram e2e test unless `RUN_TELEGRAM_E2E` is set
- read Telegram credentials from secrets in CI
- document running the full e2e test with environment variables

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo install cargo-machete --quiet`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_68697ccdd87c8332aa0749fa4f3bb5a3