### PR TITLE
Fix duplicate telegram posts in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,19 +52,6 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" != "schedule" ] || [ "$latest_post" != "$last_sent" ]; then
             rm -f output_*.md
             cargo run --quiet --bin twir-deploy-notify -- "$latest_post"
-            for file in $(ls -v output_*.md 2>/dev/null); do
-              text=$(cat "$file")
-              resp=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-                -d "chat_id=${TELEGRAM_CHAT_ID}" \
-                --data-urlencode "text=$text" \
-                -d "parse_mode=MarkdownV2" \
-                -d "disable_web_page_preview=true")
-              ok=$(echo "$resp" | jq -r '.ok')
-              if [ "$ok" != "true" ]; then
-                echo "Telegram API error: $resp"
-                exit 1
-              fi
-            done
             echo "$latest_post" > last_sent.txt
           else
             echo "No new release. Skipping Telegram notification."


### PR DESCRIPTION
## Summary
- remove the manual curl loop in the deploy workflow
- rely on the binary to send posts automatically

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686985b97afc83329454020dc1ccdc50