### PR TITLE
Fix integration test thread count

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
-      - run: cargo test --quiet --all-targets --features integration -- --test-threads=$(nproc)
+      - run: cargo test --quiet --all-targets --features integration -- --test-threads=1
 
   machete:
     needs: integration-tests


### PR DESCRIPTION
## Summary
- prevent parallelization of integration tests to reduce load

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68698d2d00408332a6864efc87f4df16