### PR TITLE
Add install command for cargo-machete

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -19,3 +19,6 @@
 ## 2025-07-05
 - Identified an issue with `split_posts` cutting lines after escape characters.
 - Added regression tests in `tests/generator.rs` verifying correct line splitting.
+
+## 2025-07-06
+- Documented local `cargo-machete` installation in README.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The Telegram API response is checked with `jq`, and the workflow fails if the se
 ## Development
 
 Continuous integration runs `cargo machete` to verify that `Cargo.toml` lists only used dependencies. Run this command locally before opening a pull request.
+Install it with `cargo install cargo-machete` if it is not available.
 
 Documentation Markdown is validated with `cargo run --bin check-docs`, which parses files using [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark).
 Generated Telegram posts are verified with the shared `validator` module.


### PR DESCRIPTION
## Summary
- document cargo-machete installation in README
- log the change in the development log

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68698d3432c88332a5481183eab67896