### PR TITLE
Update TELEGRAM_DELAY_MS

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -8,7 +8,7 @@ use crate::parser::{Section, parse_sections};
 use crate::validator::validate_telegram_markdown;
 
 pub const TELEGRAM_LIMIT: usize = 4000;
-pub const TELEGRAM_DELAY_MS: u64 = 500;
+pub const TELEGRAM_DELAY_MS: u64 = 1000;
 
 fn replace_links(text: &str) -> String {
     let mut result = String::new();


### PR DESCRIPTION
## Summary
- bump TELEGRAM_DELAY_MS constant to 1000ms
- run `cargo fmt`, `cargo check`, `cargo clippy`, `cargo test`, and `cargo machete`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68698d5eb75c83328dad5a4e88287934