### PR TITLE
Fix integration test threads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
-      - run: cargo test --quiet --all-targets --features integration -- --test-threads=$(nproc)
+      - run: cargo test --quiet --all-targets --features integration -- --test-threads=1
 
   machete:
     needs: integration-tests


### PR DESCRIPTION
## Summary
- set integration tests to run on a single thread to avoid Telegram race conditions

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=1`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68698d87a8e48332a2fe28f8c6846f84