### PR TITLE
Add scheduled cleanup of old workflow runs

### DIFF
--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -1,0 +1,36 @@
+name: Prune old workflow runs
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const cutoff = Date.now() - 14 * 24 * 60 * 60 * 1000;
+            const { owner, repo } = context.repo;
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            for (const run of runs) {
+              const created = new Date(run.created_at).getTime();
+              if (run.id === context.runId) continue;
+              if (created < cutoff || run.event === 'workflow_dispatch') {
+                await github.rest.actions.deleteWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                });
+              }
+            }
+


### PR DESCRIPTION
## Summary
- automatically prune old workflow runs via new `prune.yml`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6869966e54a08332b70cbd473d6ba21e