### PR TITLE
Use dev credentials on manual workflow runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Send latest post to Telegram
         env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_BOT_TOKEN: ${{ github.event_name == 'workflow_dispatch' && secrets.DEV_TELEGRAM_BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ github.event_name == 'workflow_dispatch' && secrets.DEV_TELEGRAM_CHAT_ID || secrets.TELEGRAM_CHAT_ID }}
         run: |
           latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n1)
           last_sent=$(cat last_sent.txt 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- update deploy workflow so that workflow_dispatch runs use dev Telegram credentials

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68699b6609d8833295512b8a4512c48d