### PR TITLE
Avoid duplicating issue number in header

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -293,7 +293,10 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
         header.push_str(&format!("**{}**", escape_markdown(t)));
     }
     if let Some(ref n) = number {
-        header.push_str(&format!(" — \\#{}", escape_markdown(n)));
+        let already_in_title = title.as_ref().map(|t| t.contains(n)).unwrap_or(false);
+        if !already_in_title {
+            header.push_str(&format!(" — \\#{}", escape_markdown(n)));
+        }
     }
     if let Some(ref d) = date {
         header.push_str(&format!(" — {}\n\n\\-\\-\\-\n", escape_markdown(d)));

--- a/tests/expected/606_1.md
+++ b/tests/expected/606_1.md
@@ -1,5 +1,5 @@
 *Part 1/11*
-**This Week in Rust 606** — \#606 — 2025\-07\-02
+**This Week in Rust 606** — 2025\-07\-02
 
 \-\-\-
 📰 **UPDATES FROM RUST COMMUNITY**

--- a/tests/expected/607_1.md
+++ b/tests/expected/607_1.md
@@ -1,5 +1,5 @@
 *Part 1/11*
-**This Week in Rust 607** — \#607 — 2025\-07\-05
+**This Week in Rust 607** — 2025\-07\-05
 
 \-\-\-
 📰 **UPDATES FROM RUST COMMUNITY**

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -1,5 +1,5 @@
 *Part 1/2*
-**This Week in Rust 607** — \#607 — 2025\-07\-05
+**This Week in Rust 607** — 2025\-07\-05
 
 \-\-\-
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS**

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -1,5 +1,5 @@
 *Part 1/13*
-**This Week in Rust 605** — \#605 — 2025\-06\-25
+**This Week in Rust 605** — 2025\-06\-25
 
 \-\-\-
 📰 **UPDATES FROM RUST COMMUNITY**


### PR DESCRIPTION
## Summary
- skip adding `#<number>` when the issue number already exists in the title
- update expected output for integration tests

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_68699a1754d483328fa83cd3bccbeb96