### PR TITLE
Add optional pinning for first Telegram message

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,10 @@ pub fn main() -> std::io::Result<()> {
     {
         let base = env::var("TELEGRAM_API_BASE")
             .unwrap_or_else(|_| "https://api.telegram.org".to_string());
-        send_to_telegram(&posts, &base, &token, &chat_id, !cli.plain)
+        let pin_first = env::var("TELEGRAM_PIN_FIRST")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        send_to_telegram(&posts, &base, &token, &chat_id, !cli.plain, pin_first)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
     }
     Ok(())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -166,7 +166,7 @@ fn send_long_escaped_dash() {
         );
     }
 
-    let result = send_to_telegram(&posts, &server.url(), "TEST", "42", true);
+    let result = send_to_telegram(&posts, &server.url(), "TEST", "42", true, false);
     assert!(result.is_ok(), "send_to_telegram failed: {result:?}");
     for m in mocks {
         m.assert();

--- a/tests/telegram_e2e.rs
+++ b/tests/telegram_e2e.rs
@@ -45,7 +45,7 @@ fn telegram_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
     let chat_id_num = chat_id.parse::<i64>().ok();
     for p in &posts {
         common::assert_valid_markdown(p);
-        send_to_telegram(&[p.clone()], &base, &token, &chat_id, true)?;
+        send_to_telegram(&[p.clone()], &base, &token, &chat_id, true, false)?;
         let updates_url = format!(
             "{}/bot{}/getUpdates?offset={}",
             base.trim_end_matches('/'),


### PR DESCRIPTION
## Summary
- introduce TELEGRAM_PIN_FIRST environment variable
- pin first sent message when enabled
- update CLI to pass pin option
- expand send_to_telegram API and tests

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68699a2563a0833293b0a144649f0c67