### PR TITLE
Add emoji mapping to headings

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -97,7 +97,11 @@ pub fn escape_markdown_url(url: &str) -> String {
 /// A bold heading prefixed with a newspaper emoji.
 pub fn format_heading(title: &str) -> String {
     let upper = title.to_uppercase();
-    format!("📰 **{}**", escape_markdown(&upper))
+    let emoji = match upper.as_str() {
+        "UPCOMING EVENTS" => "🎉",
+        _ => "📰",
+    };
+    format!("{e} **{}** {e}", escape_markdown(&upper), e = emoji)
 }
 
 /// Format a level 3 or level 4 heading.
@@ -455,7 +459,7 @@ mod tests {
         assert!(first.exists());
         let content = fs::read_to_string(first).unwrap();
         assert!(content.contains("*Part 1/2*"));
-        assert!(content.contains("📰 **NEWS**"));
+        assert!(content.contains("📰 **NEWS** 📰"));
         assert!(content.contains("[Link](https://example.com)"));
         let _ = fs::remove_dir_all(&dir);
     }
@@ -540,7 +544,7 @@ mod tests {
     #[test]
     fn heading_formatter() {
         let formatted = format_heading("My Title");
-        assert_eq!(formatted, "📰 **MY TITLE**");
+        assert_eq!(formatted, "📰 **MY TITLE** 📰");
     }
 
     #[test]

--- a/tests/expected/606_1.md
+++ b/tests/expected/606_1.md
@@ -2,7 +2,7 @@
 **This Week in Rust 606** — \#606 — 2025\-07\-02
 
 \-\-\-
-📰 **UPDATES FROM RUST COMMUNITY**
+📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**
 • [Announcing Rust 1\.88\.0 \| Rust Blog](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)
 • [Now accepting Project Goal proposals for 2025H2](https://blog.rust-lang.org/inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions/)

--- a/tests/expected/606_10.md
+++ b/tests/expected/606_10.md
@@ -1,5 +1,5 @@
 *Part 10/11*
-📰 **JOBS**
+📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
 Quote of the Week\> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
 And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\.

--- a/tests/expected/606_2.md
+++ b/tests/expected/606_2.md
@@ -1,5 +1,5 @@
 *Part 2/11*
-📰 **CRATE OF THE WEEK**
+📰 **CRATE OF THE WEEK** 📰
 This week's crate is [ansic](https://crates.io/crates/ansic), a proc macro providing a DSL to output ANSI escape strings with zero runtime overhead\.
 Thanks to [Zeon](https://users.rust-lang.org/t/crate-of-the-week/2704/1448) for the self\-suggestion\!
 [Please submit your suggestions and votes for next week](https://users.rust-lang.org/t/crate-of-the-week/2704)\!

--- a/tests/expected/606_3.md
+++ b/tests/expected/606_3.md
@@ -1,5 +1,5 @@
 *Part 3/11*
-📰 **CALLS FOR TESTING**
+📰 **CALLS FOR TESTING** 📰
 An important step for RFC implementation is for people to experiment with the implementation and give feedback, especially before stabilization\.
 If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 • No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.

--- a/tests/expected/606_4.md
+++ b/tests/expected/606_4.md
@@ -1,5 +1,5 @@
 *Part 4/11*
-📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS**
+📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
 Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
 Some of these tasks may also have mentors available, visit the task page for more information\.

--- a/tests/expected/606_5.md
+++ b/tests/expected/606_5.md
@@ -1,5 +1,5 @@
 *Part 5/11*
-📰 **UPDATES FROM THE RUST PROJECT**
+📰 **UPDATES FROM THE RUST PROJECT** 📰
 429 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-24..2025-07-01)
 **Compiler**
 • [add \#\[loop\_match\] for improved DFA codegen](https://github.com/rust-lang/rust/pull/138780)

--- a/tests/expected/606_7.md
+++ b/tests/expected/606_7.md
@@ -1,5 +1,5 @@
 *Part 7/11*
-📰 **UPCOMING EVENTS**
+🎉 **UPCOMING EVENTS** 🎉
 Rusty Events between 2025\-07\-02 \- 2025\-07\-30 🦀
 **Virtual**
 • 2025\-07\-02 \| Virtual \(Indianapolis, IN, US\) \| [Indy Rust](https://www.meetup.com/indyrs)

--- a/tests/expected/607_1.md
+++ b/tests/expected/607_1.md
@@ -2,7 +2,7 @@
 **This Week in Rust 607** — \#607 — 2025\-07\-05
 
 \-\-\-
-📰 **UPDATES FROM RUST COMMUNITY**
+📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**
 • [Announcing Rust 1\.88\.0 \| Rust Blog](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)
 • [Now accepting Project Goal proposals for 2025H2](https://blog.rust-lang.org/inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions/)

--- a/tests/expected/607_10.md
+++ b/tests/expected/607_10.md
@@ -1,5 +1,5 @@
 *Part 10/11*
-📰 **JOBS**
+📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
 Quote of the Week\> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
 And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\.

--- a/tests/expected/607_2.md
+++ b/tests/expected/607_2.md
@@ -1,5 +1,5 @@
 *Part 2/11*
-📰 **CRATE OF THE WEEK**
+📰 **CRATE OF THE WEEK** 📰
 This week's crate is [ansic](https://crates.io/crates/ansic), a proc macro providing a DSL to output ANSI escape strings with zero runtime overhead\.
 Thanks to [Zeon](https://users.rust-lang.org/t/crate-of-the-week/2704/1448) for the self\-suggestion\!
 [Please submit your suggestions and votes for next week](https://users.rust-lang.org/t/crate-of-the-week/2704)\!

--- a/tests/expected/607_3.md
+++ b/tests/expected/607_3.md
@@ -1,5 +1,5 @@
 *Part 3/11*
-📰 **CALLS FOR TESTING**
+📰 **CALLS FOR TESTING** 📰
 An important step for RFC implementation is for people to experiment with the implementation and give feedback, especially before stabilization\.
 If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 • No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.

--- a/tests/expected/607_4.md
+++ b/tests/expected/607_4.md
@@ -1,5 +1,5 @@
 *Part 4/11*
-📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS**
+📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
 Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
 Some of these tasks may also have mentors available, visit the task page for more information\.

--- a/tests/expected/607_5.md
+++ b/tests/expected/607_5.md
@@ -1,5 +1,5 @@
 *Part 5/11*
-📰 **UPDATES FROM THE RUST PROJECT**
+📰 **UPDATES FROM THE RUST PROJECT** 📰
 429 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-24..2025-07-01)
 **Compiler**
 • [add \#\[loop\_match\] for improved DFA codegen](https://github.com/rust-lang/rust/pull/138780)

--- a/tests/expected/607_7.md
+++ b/tests/expected/607_7.md
@@ -1,5 +1,5 @@
 *Part 7/11*
-📰 **UPCOMING EVENTS**
+🎉 **UPCOMING EVENTS** 🎉
 Rusty Events between 2025\-07\-02 \- 2025\-07\-30 🦀
 **Virtual**
 • 2025\-07\-02 \| Virtual \(Indianapolis, IN, US\) \| [Indy Rust](https://www.meetup.com/indyrs)

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -2,7 +2,7 @@
 **This Week in Rust 607** — \#607 — 2025\-07\-05
 
 \-\-\-
-📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS**
+📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
 Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
 Some of these tasks may also have mentors available, visit the task page for more information\.

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -2,7 +2,7 @@
 **Complex Example** — \#999 — 2025\-07\-10
 
 \-\-\-
-📰 **NESTED LIST**
+📰 **NESTED LIST** 📰
 • Item 1
   • Sub Item 1
     • Sub Sub Item 1

--- a/tests/expected/complex2.md
+++ b/tests/expected/complex2.md
@@ -1,5 +1,5 @@
 *Part 2/5*
-📰 **QUOTE BLOCK**
+📰 **QUOTE BLOCK** 📰
 \> First level quote line 1 First level quote line 2
 \> Nested quote line
 

--- a/tests/expected/complex3.md
+++ b/tests/expected/complex3.md
@@ -1,5 +1,5 @@
 *Part 3/5*
-📰 **CODE BLOCK**
+📰 **CODE BLOCK** 📰
 ```
 fn greet\(\) \{
     println\!\("Hello, world\!"\);

--- a/tests/expected/complex4.md
+++ b/tests/expected/complex4.md
@@ -1,5 +1,5 @@
 *Part 4/5*
-📰 **TABLE EXAMPLE**
+📰 **TABLE EXAMPLE** 📰
 | Short | Much Longer Column | C  |
 | 1     | a                  | 3  |
 | 2     | abcdef             | 44 |

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -2,7 +2,7 @@
 **This Week in Rust 605** — \#605 — 2025\-06\-25
 
 \-\-\-
-📰 **UPDATES FROM RUST COMMUNITY**
+📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**
 • [Announcing the Clippy feature freeze](https://blog.rust-lang.org/inside-rust/2025/06/21/announcing-the-clippy-feature-freeze/)
 **Newsletters**

--- a/tests/expected/expected10.md
+++ b/tests/expected/expected10.md
@@ -1,4 +1,6 @@
 *Part 10/13*
+  • [TUI Power: Simulating & Visualising Sensor Data with Rust](https://www.meetup.com/london-rust-project-group/events/308434768)
+**North America**
 • 2025\-06\-25 \| Austin, TX, US \| [Rust ATX](https://www.meetup.com/rust-atx)
   • [Rust Lunch \- Fareground](https://www.meetup.com/rust-atx/events/xvkdgtyhcjbhc)
 • 2025\-06\-26 \| Chicago, IL, US \| [Chicago Rust Meetup](https://www.meetup.com/chicago-rust-meetup/events/)

--- a/tests/expected/expected12.md
+++ b/tests/expected/expected12.md
@@ -1,5 +1,5 @@
 *Part 12/13*
-📰 **JOBS**
+📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1knkfb6/official_rrust_whos_hiring_thread_for_jobseekers/)
 Quote of the Week\> Our experience is that no matter how many safeguards you put on code, there’s no cure\-all that prevents bad programming\. Of course, to take the contrary argument, seat belts don’t stop all traffic fatalities, but you could just choose not to have accidents\. So we do have seat belts\. If Rust can prevent some mistakes or malicious intent, maybe it’s worth it even if it isn’t perfect\.
 

--- a/tests/expected/expected2.md
+++ b/tests/expected/expected2.md
@@ -1,5 +1,5 @@
 *Part 2/13*
-📰 **CRATE OF THE WEEK**
+📰 **CRATE OF THE WEEK** 📰
 This week's crate is [primitive\_fixed\_point\_decimal](https://docs.rs/primitive_fixed_point_decimal), a crate of real fixed\-point decimal types\.
 Thanks to [Wu Bingzheng](https://users.rust-lang.org/t/crate-of-the-week/2704/1445) for the self\-suggestion\!
 [Please submit your suggestions and votes for next week](https://users.rust-lang.org/t/crate-of-the-week/2704)\!

--- a/tests/expected/expected3.md
+++ b/tests/expected/expected3.md
@@ -1,5 +1,5 @@
 *Part 3/13*
-📰 **CALLS FOR TESTING**
+📰 **CALLS FOR TESTING** 📰
 An important step for RFC implementation is for people to experiment with the implementation and give feedback, especially before stabilization\.
 If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 • No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -1,5 +1,5 @@
 *Part 4/13*
-📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS**
+📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
 Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
 Some of these tasks may also have mentors available, visit the task page for more information\.

--- a/tests/expected/expected5.md
+++ b/tests/expected/expected5.md
@@ -1,5 +1,5 @@
 *Part 5/13*
-📰 **UPDATES FROM THE RUST PROJECT**
+📰 **UPDATES FROM THE RUST PROJECT** 📰
 448 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-17..2025-06-24)
 **Compiler**
 • [perf: Cache the canonical instantiation of param\-envs](https://github.com/rust-lang/rust/pull/142316)

--- a/tests/expected/expected8.md
+++ b/tests/expected/expected8.md
@@ -1,5 +1,5 @@
 *Part 8/13*
-📰 **UPCOMING EVENTS**
+🎉 **UPCOMING EVENTS** 🎉
 Rusty Events between 2025\-06\-25 \- 2025\-07\-23 🦀
 **Virtual**
 • 2025\-06\-25 \| Virtual \(Lima, PE\)\| [Perú Rust User Group](https://www.meetup.com/peru-rust-user-group/)
@@ -40,4 +40,3 @@ Rusty Events between 2025\-06\-25 \- 2025\-07\-23 🦀
   • [Lunch & Learn: Crates, Tips & Tricks Lightning Talks \- Bring your ideas\!](https://www.meetup.com/women-in-rust/events/307560304)
 **Asia**
 • 2025\-06\-28 \| Bangalore/Bengaluru, IN \| [Rust Bangalore](https://hasgeek.com/rustbangalore)
-  • [June 2025 Rustacean meetup](https://hasgeek.com/rustbangalore/june-2025-rustacean-meetup/)

--- a/tests/expected/expected9.md
+++ b/tests/expected/expected9.md
@@ -1,4 +1,5 @@
 *Part 9/13*
+  • [June 2025 Rustacean meetup](https://hasgeek.com/rustbangalore/june-2025-rustacean-meetup/)
 • 2025\-07\-02 \| Seoul, KR \| [Seoul Rust \(Programming Language\) Meetup](https://www.meetup.com/rust-seoul-meetup/events/)
   • [Seoul Rust Meetup](https://www.meetup.com/rust-seoul-meetup/events/308408246)
 **Europe**
@@ -37,5 +38,3 @@
 • 2025\-07\-15 \| Leipzig, DE \| [Rust \- Modern Systems Programming in Leipzig](https://www.meetup.com/rust-modern-systems-programming-in-leipzig/events/)
   • [Topic TBD](https://www.meetup.com/rust-modern-systems-programming-in-leipzig/events/308592246)
 • 2025\-07\-15 \| London, UK \| [London Rust Project Group](https://www.meetup.com/london-rust-project-group/events/)
-  • [TUI Power: Simulating & Visualising Sensor Data with Rust](https://www.meetup.com/london-rust-project-group/events/308434768)
-**North America**

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -23,7 +23,7 @@ fn crate_of_the_week_is_preserved() {
     assert!(status.success());
 
     let output = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
-    assert!(output.contains("📰 **CRATE OF THE WEEK**"));
+    assert!(output.contains("📰 **CRATE OF THE WEEK** 📰"));
     assert!(output.contains("primitive\\_fixed\\_point\\_decimal"));
     common::assert_valid_markdown(&output);
 }
@@ -44,9 +44,9 @@ fn crate_of_week_followed_by_section() {
 
     let first = fs::read_to_string(dir.path().join("output_1.md")).unwrap();
     let second = fs::read_to_string(dir.path().join("output_2.md")).unwrap();
-    assert!(first.contains("📰 **CRATE OF THE WEEK**"));
+    assert!(first.contains("📰 **CRATE OF THE WEEK** 📰"));
     assert!(first.contains("[demo](https://example.com)"));
-    assert!(second.contains("📰 **NEXT**"));
+    assert!(second.contains("📰 **NEXT** 📰"));
     common::assert_valid_markdown(&first);
     common::assert_valid_markdown(&second);
 }


### PR DESCRIPTION
## Summary
- choose emojis based on section name
- place emoji on both sides of heading text
- update expected output and integration tests

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68699a20936883328c78a5d48395720d