### PR TITLE
Remove header separator

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -303,7 +303,7 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
         }
     }
     if let Some(ref d) = date {
-        header.push_str(&format!(" — {}\n\n\\-\\-\\-\n", escape_markdown(d)));
+        header.push_str(&format!(" — {}\n\n", escape_markdown(d)));
     }
 
     let mut current_post = String::new();

--- a/tests/expected/606_1.md
+++ b/tests/expected/606_1.md
@@ -1,7 +1,6 @@
 *Part 1/8*
 **This Week in Rust 606** — 2025\-07\-02
 
-\-\-\-
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**
 • [Announcing Rust 1\.88\.0 \| Rust Blog](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)

--- a/tests/expected/607_1.md
+++ b/tests/expected/607_1.md
@@ -1,7 +1,6 @@
 *Part 1/8*
 **This Week in Rust 607** — 2025\-07\-05
 
-\-\-\-
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**
 • [Announcing Rust 1\.88\.0 \| Rust Blog](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -1,7 +1,6 @@
 *Part 1/1*
 **This Week in Rust 607** — 2025\-07\-05
 
-\-\-\-
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
 Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -1,7 +1,6 @@
 *Part 1/1*
 **Complex Example** — \#999 — 2025\-07\-10
 
-\-\-\-
 📰 **NESTED LIST** 📰
 • Item 1
   • Sub Item 1

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -1,7 +1,6 @@
 *Part 1/10*
 **This Week in Rust 605** — 2025\-06\-25
 
-\-\-\-
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**
 • [Announcing the Clippy feature freeze](https://blog.rust-lang.org/inside-rust/2025/06/21/announcing-the-clippy-feature-freeze/)


### PR DESCRIPTION
## Summary
- drop initial `---` from first post header
- update expected test outputs

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `cargo run --bin check-docs`


------
https://chatgpt.com/codex/tasks/task_e_6869a404a9e8833283bb1ccd039b3a24