### PR TITLE
Update CI to run Telegram tests manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run_integration:
+        description: "Run Telegram integration tests"
+        required: false
+        default: "false"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -58,6 +64,7 @@ jobs:
       - run: cargo test --quiet --all-targets --all-features -- --test-threads=$(nproc)
 
   integration-tests:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.run_integration == 'true'
     needs: test
     runs-on: ubuntu-latest
     env:
@@ -72,7 +79,7 @@ jobs:
       - run: cargo test --quiet --all-targets --features integration -- --test-threads=1
 
   machete:
-    needs: integration-tests
+    needs: test
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_PROGRESS_WHEN: never

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -22,3 +22,7 @@
 
 ## 2025-07-06
 - Documented local `cargo-machete` installation in README.
+
+## 2025-07-07
+- Telegram integration tests are no longer executed automatically.
+- They can be run manually by dispatching the CI workflow with `run_integration` set to `true`.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ Install it with `cargo install cargo-machete` if it is not available.
 
 Documentation Markdown is validated with `cargo run --bin check-docs`, which parses files using [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark).
 Generated Telegram posts are verified with the shared `validator` module.
+Integration tests that send messages to Telegram run only when the CI workflow is manually triggered with the `run_integration` input.


### PR DESCRIPTION
## Summary
- allow running the CI workflow manually
- skip Telegram integration tests unless run manually
- document manual integration tests in the README
- note the change in `DEVLOG.md`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869a50f53a883328d2f195fd2298912