### PR TITLE
Update link label

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -283,7 +283,7 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
         link_section.lines.push("\\-\\-\\-".to_string());
         link_section.lines.push(String::new());
         link_section.lines.push(format!(
-            "📖 Full issue: [{}]({})",
+            "📖 View web version: [{}]({})",
             escape_markdown(link),
             escape_markdown_url(link)
         ));

--- a/tests/expected/606_8.md
+++ b/tests/expected/606_8.md
@@ -12,4 +12,4 @@ Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust
 [Discuss on r/rust](https://www.reddit.com/r/rust/comments/1lqe66f/this_week_in_rust_606/)
 \-\-\-
 
-📖 Full issue: [https://this\-week\-in\-rust\.org/blog/2025/07/02/this\-week\-in\-rust\-606/](https://this-week-in-rust.org/blog/2025/07/02/this-week-in-rust-606/)
+📖 View web version: [https://this\-week\-in\-rust\.org/blog/2025/07/02/this\-week\-in\-rust\-606/](https://this-week-in-rust.org/blog/2025/07/02/this-week-in-rust-606/)

--- a/tests/expected/607_8.md
+++ b/tests/expected/607_8.md
@@ -12,4 +12,4 @@ Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust
 [Discuss on r/rust](https://www.reddit.com/r/rust/comments/1lqe66f/this_week_in_rust_607/)
 \-\-\-
 
-📖 Full issue: [https://this\-week\-in\-rust\.org/blog/2025/07/05/this\-week\-in\-rust\-607/](https://this-week-in-rust.org/blog/2025/07/05/this-week-in-rust-607/)
+📖 View web version: [https://this\-week\-in\-rust\.org/blog/2025/07/05/this\-week\-in\-rust\-607/](https://this-week-in-rust.org/blog/2025/07/05/this-week-in-rust-607/)

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -14,4 +14,4 @@ No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
 \-\-\-
 
-📖 Full issue: [https://this\-week\-in\-rust\.org/blog/2025/07/05/this\-week\-in\-rust\-607/](https://this-week-in-rust.org/blog/2025/07/05/this-week-in-rust-607/)
+📖 View web version: [https://this\-week\-in\-rust\.org/blog/2025/07/05/this\-week\-in\-rust\-607/](https://this-week-in-rust.org/blog/2025/07/05/this-week-in-rust-607/)

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -25,4 +25,4 @@ fn greet\(\) \{
 | 2     | abcdef             | 44 |
 \-\-\-
 
-📖 Full issue: [https://this\-week\-in\-rust\.org/blog/2025/07/10/this\-week\-in\-rust\-999/](https://this-week-in-rust.org/blog/2025/07/10/this-week-in-rust-999/)
+📖 View web version: [https://this\-week\-in\-rust\.org/blog/2025/07/10/this\-week\-in\-rust\-999/](https://this-week-in-rust.org/blog/2025/07/10/this-week-in-rust-999/)

--- a/tests/expected/expected10.md
+++ b/tests/expected/expected10.md
@@ -11,4 +11,4 @@ Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust
 [Discuss on r/rust](https://www.reddit.com/r/rust/comments/1lknjc1/this_week_in_rust_605/)
 \-\-\-
 
-📖 Full issue: [https://this\-week\-in\-rust\.org/blog/2025/06/25/this\-week\-in\-rust\-605/](https://this-week-in-rust.org/blog/2025/06/25/this-week-in-rust-605/)
+📖 View web version: [https://this\-week\-in\-rust\.org/blog/2025/06/25/this\-week\-in\-rust\-605/](https://this-week-in-rust.org/blog/2025/06/25/this-week-in-rust-605/)


### PR DESCRIPTION
## Summary
- rename the link label from "Full issue" to "View web version"
- update expected outputs

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869a5b4f6bc83329e30011444091d20