### PR TITLE
Add PR cancellation workflow

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,31 @@
+name: Cancel PR CI
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner,
+              repo,
+              event: 'pull_request',
+              per_page: 100,
+            });
+            for (const run of runs) {
+              const prNums = run.pull_requests.map(pr => pr.number);
+              if (prNums.includes(prNumber) && ['queued','in_progress','waiting'].includes(run.status)) {
+                await github.rest.actions.cancelWorkflowRun({ owner, repo, run_id: run.id });
+              }
+            }

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -26,3 +26,6 @@
 ## 2025-07-07
 - Telegram integration tests are no longer executed automatically.
 - They can be run manually by dispatching the CI workflow with `run_integration` set to `true`.
+
+## 2025-07-08
+- Added workflow to cancel CI jobs when a pull request is merged.


### PR DESCRIPTION
## Summary
- cancel CI workflow runs when a pull request is merged
- document new workflow in `DEVLOG`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869abcee048833291ce80b7ce26c561