### PR TITLE
Добавить правила ведения DEVLOG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,6 @@
 - Read all Markdown (`*.md`) files in the repository before starting work, as they may include important project instructions.
 - Follow the guidelines in `PARSING.md`, especially the requirement to rely on crates for Markdown processing instead of custom parsing code.
 
+- Keep `DEVLOG.md` trimmed to the latest 20 entries; remove the oldest when adding a new one.
+
 - Avoid committed dead code; remove unused functions or feature-gate them.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -26,3 +26,7 @@
 ## 2025-07-07
 - Telegram integration tests are no longer executed automatically.
 - They can be run manually by dispatching the CI workflow with `run_integration` set to `true`.
+
+## Maintenance
+The development log keeps only the 20 most recent entries.
+When adding a new entry, delete the oldest if there are already 20.


### PR DESCRIPTION
## Изменения
- добавлен раздел `Maintenance` в `DEVLOG.md` с описанием лимита в 20 записей
- обновлены инструкции в `AGENTS.md` согласно новому правилу

## Тестирование
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869ac85a1f083328039fb682dcd8fa7