### PR TITLE
Fix Quote of the Week formatting

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -190,6 +190,9 @@ pub fn parse_sections(text: &str) -> Vec<Section> {
                 }
             }
             Event::Start(Tag::BlockQuote) => {
+                if !buffer.is_empty() && !buffer.ends_with('\n') {
+                    buffer.push('\n');
+                }
                 buffer.push_str("\\> ");
             }
             Event::End(Tag::BlockQuote) => {

--- a/tests/expected/606_5.md
+++ b/tests/expected/606_5.md
@@ -1,7 +1,8 @@
 *Part 5/5*
 📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
-Quote of the Week\> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
+Quote of the Week
+\> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
 And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\.
 
 – [Remo Senekowitsch blogging about their Rust 4 Linux adventure](https://blog.buenzli.dev/rust-for-linux-first-contrib/)

--- a/tests/expected/607_5.md
+++ b/tests/expected/607_5.md
@@ -1,7 +1,8 @@
 *Part 5/5*
 📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
-Quote of the Week\> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
+Quote of the Week
+\> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
 And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\.
 
 – [Remo Senekowitsch blogging about their Rust 4 Linux adventure](https://blog.buenzli.dev/rust-for-linux-first-contrib/)

--- a/tests/expected/expected6.md
+++ b/tests/expected/expected6.md
@@ -1,7 +1,8 @@
 *Part 6/6*
 📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1knkfb6/official_rrust_whos_hiring_thread_for_jobseekers/)
-Quote of the Week\> Our experience is that no matter how many safeguards you put on code, there’s no cure\-all that prevents bad programming\. Of course, to take the contrary argument, seat belts don’t stop all traffic fatalities, but you could just choose not to have accidents\. So we do have seat belts\. If Rust can prevent some mistakes or malicious intent, maybe it’s worth it even if it isn’t perfect\.
+Quote of the Week
+\> Our experience is that no matter how many safeguards you put on code, there’s no cure\-all that prevents bad programming\. Of course, to take the contrary argument, seat belts don’t stop all traffic fatalities, but you could just choose not to have accidents\. So we do have seat belts\. If Rust can prevent some mistakes or malicious intent, maybe it’s worth it even if it isn’t perfect\.
 
 – [Al Williams on hackaday](https://hackaday.com/2025/06/21/if-your-kernel-development-is-a-little-rusty/)
 Thanks to [Kill The Mule](https://users.rust-lang.org/t/twir-quote-of-the-week/328/1700) for the suggestion\!


### PR DESCRIPTION
## Summary
- show quote blocks on a new line by adding a newline before blockquotes
- update expected outputs for Quote of the Week tests

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869ae1271d8833290bc8082de520d93