### PR TITLE
Update Jobs section links

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -27,6 +27,10 @@
 - Telegram integration tests are no longer executed automatically.
 - They can be run manually by dispatching the CI workflow with `run_integration` set to `true`.
 
+## 2025-07-08
+- Added Rust Jobs chat and feed links to the generated Jobs section.
+- Updated tests and expected outputs accordingly.
+
 ## Maintenance
 The development log keeps only the 20 most recent entries.
 When adding a new entry, delete the oldest if there are already 20.

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -277,6 +277,20 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
 
     let body = strip_header(&input);
     let mut sections = parse_sections(&body);
+    for sec in &mut sections {
+        if sec.title.eq_ignore_ascii_case("Jobs") && !sec.lines.is_empty() {
+            let chat = format!(
+                "💼 [Rust Jobs chat]({})",
+                escape_markdown_url("https://t.me/rust_jobs")
+            );
+            let feed = format!(
+                "📢 [Rust Jobs feed]({})",
+                escape_markdown_url("https://t.me/rust_jobs_feed")
+            );
+            sec.lines.insert(1, chat);
+            sec.lines.insert(2, feed);
+        }
+    }
     let mut events_link = None;
     sections.retain(|s| {
         if s.title.eq_ignore_ascii_case("Upcoming Events") {

--- a/tests/expected/606_5.md
+++ b/tests/expected/606_5.md
@@ -1,6 +1,8 @@
 *Part 5/5*
 📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
+💼 [Rust Jobs chat](https://t.me/rust_jobs)
+📢 [Rust Jobs feed](https://t.me/rust_jobs_feed)
 Quote of the Week
 \> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
 And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\.

--- a/tests/expected/607_5.md
+++ b/tests/expected/607_5.md
@@ -1,6 +1,8 @@
 *Part 5/5*
 📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
+💼 [Rust Jobs chat](https://t.me/rust_jobs)
+📢 [Rust Jobs feed](https://t.me/rust_jobs_feed)
 Quote of the Week
 \> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
 And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\.

--- a/tests/expected/expected6.md
+++ b/tests/expected/expected6.md
@@ -1,6 +1,8 @@
 *Part 6/6*
 📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1knkfb6/official_rrust_whos_hiring_thread_for_jobseekers/)
+💼 [Rust Jobs chat](https://t.me/rust_jobs)
+📢 [Rust Jobs feed](https://t.me/rust_jobs_feed)
 Quote of the Week
 \> Our experience is that no matter how many safeguards you put on code, there’s no cure\-all that prevents bad programming\. Of course, to take the contrary argument, seat belts don’t stop all traffic fatalities, but you could just choose not to have accidents\. So we do have seat belts\. If Rust can prevent some mistakes or malicious intent, maybe it’s worth it even if it isn’t perfect\.
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -175,3 +175,12 @@ fn parse_call_for_participation() {
         common::assert_valid_markdown(post);
     }
 }
+
+#[test]
+fn jobs_links_present() {
+    let input = include_str!("2025-07-05-this-week-in-rust.md");
+    let posts = generate_posts(input.to_string()).unwrap();
+    let combined = posts.join("\n");
+    assert!(combined.contains("[Rust Jobs chat](https://t.me/rust_jobs)"));
+    assert!(combined.contains("[Rust Jobs feed](https://t.me/rust_jobs_feed)"));
+}


### PR DESCRIPTION
## Summary
- inject Rust Jobs chat & feed links in Jobs section
- update expected markdown outputs
- check that generated posts include the new links
- document the change in DEVLOG

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869b2836b5483329ac181816289bf5d