### PR TITLE
Remove redundant link separator

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -27,6 +27,9 @@
 - Telegram integration tests are no longer executed automatically.
 - They can be run manually by dispatching the CI workflow with `run_integration` set to `true`.
 
+## 2025-07-08
+- Removed extraneous separator line from web link section and updated tests.
+
 ## Maintenance
 The development log keeps only the 20 most recent entries.
 When adding a new entry, delete the oldest if there are already 20.

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -289,7 +289,6 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
 
     if let Some(link) = url.as_ref() {
         let mut link_section = Section::default();
-        link_section.lines.push("\\-\\-\\-".to_string());
         link_section.lines.push(String::new());
         link_section.lines.push(format!(
             "🌐 [View web version]({}) 🌐",

--- a/tests/expected/606_5.md
+++ b/tests/expected/606_5.md
@@ -11,7 +11,6 @@ Despite a lamentable lack of suggestions, llogiq is reasonably pleased with his 
 This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [U007D](https://github.com/U007D), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin), [bennyvasquez](https://github.com/bennyvasquez), [bdillo](https://github.com/bdillo)
 Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust-lang.org/)
 [Discuss on r/rust](https://www.reddit.com/r/rust/comments/1lqe66f/this_week_in_rust_606/)
-\-\-\-
 
 🌐 [View web version](https://this-week-in-rust.org/blog/2025/07/02/this-week-in-rust-606/) 🌐
 🎉 [Upcoming Events](https://this-week-in-rust.org/blog/2025/07/02/this-week-in-rust-606/#upcoming-events)

--- a/tests/expected/607_5.md
+++ b/tests/expected/607_5.md
@@ -11,7 +11,6 @@ Despite a lamentable lack of suggestions, llogiq is reasonably pleased with his 
 This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [U007D](https://github.com/U007D), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin), [bennyvasquez](https://github.com/bennyvasquez), [bdillo](https://github.com/bdillo)
 Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust-lang.org/)
 [Discuss on r/rust](https://www.reddit.com/r/rust/comments/1lqe66f/this_week_in_rust_607/)
-\-\-\-
 
 🌐 [View web version](https://this-week-in-rust.org/blog/2025/07/05/this-week-in-rust-607/) 🌐
 🎉 [Upcoming Events](https://this-week-in-rust.org/blog/2025/07/05/this-week-in-rust-607/#upcoming-events)

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -11,6 +11,5 @@ If you are a Rust project owner and are looking for contributors, please submit 
 Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker\.
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
-\-\-\-
 
 🌐 [View web version](https://this-week-in-rust.org/blog/2025/07/05/this-week-in-rust-607/) 🌐

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -22,6 +22,5 @@ fn greet\(\) \{
 | Short | Much Longer Column | C  |
 | 1     | a                  | 3  |
 | 2     | abcdef             | 44 |
-\-\-\-
 
 🌐 [View web version](https://this-week-in-rust.org/blog/2025/07/10/this-week-in-rust-999/) 🌐

--- a/tests/expected/expected6.md
+++ b/tests/expected/expected6.md
@@ -10,7 +10,6 @@ Thanks to [Kill The Mule](https://users.rust-lang.org/t/twir-quote-of-the-week/3
 This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [U007D](https://github.com/U007D), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin), [bennyvasquez](https://github.com/bennyvasquez), [bdillo](https://github.com/bdillo)
 Email list hosting is sponsored by [The Rust Foundation](https://foundation.rust-lang.org/)
 [Discuss on r/rust](https://www.reddit.com/r/rust/comments/1lknjc1/this_week_in_rust_605/)
-\-\-\-
 
 🌐 [View web version](https://this-week-in-rust.org/blog/2025/06/25/this-week-in-rust-605/) 🌐
 🎉 [Upcoming Events](https://this-week-in-rust.org/blog/2025/06/25/this-week-in-rust-605/#upcoming-events)


### PR DESCRIPTION
## Summary
- avoid adding `---` line before the web link section
- update expected fixtures accordingly
- record change in `DEVLOG`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869b27368fc8332a91bf5b290e69545