### PR TITLE
format special subheadings

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -112,7 +112,17 @@ pub fn format_heading(title: &str) -> String {
 /// # Returns
 /// The escaped heading wrapped in bold markers.
 pub fn format_subheading(title: &str) -> String {
-    format!("**{}**", escape_markdown(title))
+    let trimmed = title.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if lower == "newsletters" {
+        format!("\n**{}:** 📰", escape_markdown(trimmed))
+    } else if lower == "project/tooling updates" {
+        format!("\n**{}:** 🛠️", escape_markdown(trimmed))
+    } else if lower == "observations/thoughts" {
+        format!("\n**{}:** 🤔", escape_markdown(trimmed))
+    } else {
+        format!("**{}**", escape_markdown(trimmed))
+    }
 }
 
 /// Convert Telegram Markdown to a plain text representation.

--- a/tests/expected/606_1.md
+++ b/tests/expected/606_1.md
@@ -7,9 +7,11 @@
 • [Now accepting Project Goal proposals for 2025H2](https://blog.rust-lang.org/inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions/)
 • [2025 Leadership Council Survey](https://blog.rust-lang.org/inside-rust/2025/06/30/2025-leadership-council-survey/)
 • [Program management update — June 2025](https://blog.rust-lang.org/inside-rust/2025/06/30/program-management-update-2025-06/)
-**Newsletters**
+
+**Newsletters:** 📰
 • [Rust Trends Issue \#68 Special](https://rust-trends.com/newsletter/join-the-rust-programming-contest-win-a-keychron-q1-airpods-pro-2-or-oura-ring-4/)
-**Project/Tooling Updates**
+
+**Project/Tooling Updates:** 🛠️
 • [Announcing TokioConf 2026](https://tokio.rs/blog/2025-06-19-announcing-tokio-conf)
 • [rust\-analyzer Changelog \#292](https://rust-analyzer.github.io/thisweek/2025/06/30/changelog-292.html)
 • [How to write Rust in the kernel: part 2](https://lwn.net/SubscriberLink/1025232/4a7776eb2f0379cf/)
@@ -17,7 +19,8 @@
 • [Diesel Async 0\.6\.0](https://blog.weiznich.de/blog/diesel-async-0-6/)
 • [Kiorg \- a new lightingly fast cross\-platform filemanager with VIM inspired keybind](https://github.com/houqp/kiorg/releases/tag/v0.1.1)
 • [Progress report on rustc\_codegen\_cranelift \(June 2025\)](https://bjorn3.github.io/2025/06/30/progress-report-june-2025.html)
-**Observations/Thoughts**
+
+**Observations/Thoughts:** 🤔
 • [How much code does that proc macro generate?](https://nnethercote.github.io/2025/06/26/how-much-code-does-that-proc-macro-generate.html)
 • [Leaktracer: A Rust allocator to trace memory allocations](https://blog.veeso.dev/blog/en/leaktracer-a-rust-allocator-to-trace-memory-allocations/)
 • [Cross\-Compiling 10,000\+ Rust CLI Crates Statically](https://blog.pkgforge.dev/cross-compiling-10000-rust-cli-crates-statically)

--- a/tests/expected/607_1.md
+++ b/tests/expected/607_1.md
@@ -7,9 +7,11 @@
 • [Now accepting Project Goal proposals for 2025H2](https://blog.rust-lang.org/inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions/)
 • [2025 Leadership Council Survey](https://blog.rust-lang.org/inside-rust/2025/06/30/2025-leadership-council-survey/)
 • [Program management update — June 2025](https://blog.rust-lang.org/inside-rust/2025/06/30/program-management-update-2025-06/)
-**Newsletters**
+
+**Newsletters:** 📰
 • [Rust Trends Issue \#68 Special](https://rust-trends.com/newsletter/join-the-rust-programming-contest-win-a-keychron-q1-airpods-pro-2-or-oura-ring-4/)
-**Project/Tooling Updates**
+
+**Project/Tooling Updates:** 🛠️
 • [Announcing TokioConf 2026](https://tokio.rs/blog/2025-06-19-announcing-tokio-conf)
 • [rust\-analyzer Changelog \#292](https://rust-analyzer.github.io/thisweek/2025/06/30/changelog-292.html)
 • [How to write Rust in the kernel: part 2](https://lwn.net/SubscriberLink/1025232/4a7776eb2f0379cf/)
@@ -17,7 +19,8 @@
 • [Diesel Async 0\.6\.0](https://blog.weiznich.de/blog/diesel-async-0-6/)
 • [Kiorg \- a new lightingly fast cross\-platform filemanager with VIM inspired keybind](https://github.com/houqp/kiorg/releases/tag/v0.1.1)
 • [Progress report on rustc\_codegen\_cranelift \(June 2025\)](https://bjorn3.github.io/2025/06/30/progress-report-june-2025.html)
-**Observations/Thoughts**
+
+**Observations/Thoughts:** 🤔
 • [How much code does that proc macro generate?](https://nnethercote.github.io/2025/06/26/how-much-code-does-that-proc-macro-generate.html)
 • [Leaktracer: A Rust allocator to trace memory allocations](https://blog.veeso.dev/blog/en/leaktracer-a-rust-allocator-to-trace-memory-allocations/)
 • [Cross\-Compiling 10,000\+ Rust CLI Crates Statically](https://blog.pkgforge.dev/cross-compiling-10000-rust-cli-crates-statically)

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -4,13 +4,16 @@
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**
 • [Announcing the Clippy feature freeze](https://blog.rust-lang.org/inside-rust/2025/06/21/announcing-the-clippy-feature-freeze/)
-**Newsletters**
+
+**Newsletters:** 📰
 • [Rust Trends Issue \#67](https://rust-trends.com/newsletter/untangling-rust-errors-the-bzip2-rewrite/)
-**Project/Tooling Updates**
+
+**Project/Tooling Updates:** 🛠️
 • [Tantivy 0\.24](https://quickwit.io/blog/tantivy-0.24)
 • [How to write Rust in the kernel: part 1](https://lwn.net/SubscriberLink/1024202/556fa7b3c51d7899/)
 • [GlueSQL v0\.17\.0 \- Added redb storage support](https://github.com/gluesql/gluesql/releases/tag/v0.17.0)
-**Observations/Thoughts**
+
+**Observations/Thoughts:** 🤔
 • [The Unreasonable Effectiveness of Fuzzing for Porting Programs](https://rjp.io/blog/2025-06-17-unreasonable-effectiveness-of-fuzzing)
 • [So you want to serialize some DER?](https://alexgaynor.net/2025/jun/20/serialize-some-der/)
 • [Why I Switched from Flutter \+ Rust to Rust \+ egui](https://jdiaz97.github.io/greenblog/posts/flutter_to_egui/)


### PR DESCRIPTION
## Summary
- add emoji and colon formatting for subheadings
- update expected markdown outputs

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869b0efc4548332bff582556a99f15d