### PR TITLE
Document TELEGRAM_PIN_FIRST and enable pin in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ github.event_name == 'workflow_dispatch' && secrets.DEV_TELEGRAM_BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ github.event_name == 'workflow_dispatch' && secrets.DEV_TELEGRAM_CHAT_ID || secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_PIN_FIRST: '1'
         run: |
           latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n1)
           last_sent=$(cat last_sent.txt 2>/dev/null || echo "")

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Set `RUST_LOG=info` to see detailed logs including Telegram API responses:
 RUST_LOG=info cargo run --bin twir-deploy-notify -- twir/content/<file-name>.md
 ```
 
+## Configuration
+
+The application expects several environment variables when sending posts to
+Telegram:
+
+- `TELEGRAM_BOT_TOKEN` – the bot token used for authentication.
+- `TELEGRAM_CHAT_ID` – the identifier of the chat or channel.
+- `TELEGRAM_PIN_FIRST` – set to `1` or `true` to pin the first sent message.
+
 Running the workflow with [`act`](https://github.com/nektos/act) is possible, but it requires Docker.
 Restricted environments such as the provided container may not support Docker, so executing the above
 `cargo` commands manually remains the recommended approach.


### PR DESCRIPTION
## Summary
- describe required environment variables in README
- pin the first Telegram message in the deploy workflow

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869b8d9042c8332a435e08baffbdb39