### PR TITLE
Удаление уведомления о закреплении

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -37,6 +37,10 @@
 - Added short instruction link and removed the events link at the bottom.
 - Updated expected test outputs accordingly.
 
+## 2025-07-10
+- Pinned posts now remove the automatic notification using `deleteMessage`.
+- Updated integration tests for the new behavior.
+
 ## Maintenance
 The development log keeps only the 20 most recent entries.
 When adding a new entry, delete the oldest if there are already 20.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Telegram:
 - `TELEGRAM_BOT_TOKEN` – the bot token used for authentication.
 - `TELEGRAM_CHAT_ID` – the identifier of the chat or channel.
 - `TELEGRAM_PIN_FIRST` – set to `1` or `true` to pin the first sent message.
+  The service message about the pin will be deleted automatically.
 
 Running the workflow with [`act`](https://github.com/nektos/act) is possible, but it requires Docker.
 Restricted environments such as the provided container may not support Docker, so executing the above

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::{fs, path::Path, thread, time::Duration};
@@ -556,6 +556,29 @@ pub fn send_to_telegram(
                     pin_data.description.unwrap_or_default()
                 )
                 .into());
+            }
+
+            // Attempt to remove the service message about the pinned post.
+            let delete_url = format!(
+                "{}/bot{}/deleteMessage",
+                base_url.trim_end_matches('/'),
+                token
+            );
+            let notif_id = (result.message_id + 1).to_string();
+            let delete_form = vec![("chat_id", chat_id), ("message_id", &notif_id)];
+            let resp = client.post(&delete_url).form(&delete_form).send()?;
+            let status = resp.status();
+            let body = resp.text()?;
+            debug!("Telegram delete response {status}: {body}");
+            let delete_data: TelegramResponse<()> = serde_json::from_str(&body)
+                .map_err(|e| format!("Failed to parse Telegram delete response: {e}: {body}"))?;
+            if !delete_data.ok {
+                warn!(
+                    "Telegram error deleting pin notification {} {}: {}",
+                    notif_id,
+                    delete_data.error_code.unwrap_or_default(),
+                    delete_data.description.as_deref().unwrap_or("unknown")
+                );
             }
         }
         thread::sleep(Duration::from_millis(TELEGRAM_DELAY_MS));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -309,8 +309,21 @@ fn pin_first_message() {
         .expect(1)
         .create();
 
+    let m3 = server
+        .mock("POST", "/botTEST/deleteMessage")
+        .match_header("content-type", "application/x-www-form-urlencoded")
+        .match_body(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("chat_id".into(), "42".into()),
+            Matcher::UrlEncoded("message_id".into(), "2".into()),
+        ]))
+        .with_status(200)
+        .with_body("{\"ok\":true}")
+        .expect(1)
+        .create();
+
     generator::send_to_telegram(&posts, &server.url(), "TEST", "42", true, true).unwrap();
     m1.assert();
     m2.assert();
+    m3.assert();
     common::assert_valid_markdown(&posts[0]);
 }


### PR DESCRIPTION
## Summary
- delete the service notification after pinning the first message
- update integration tests for deleteMessage
- document automatic pin notification removal
- log the new behavior in DEVLOG

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869be9594408332a217670642b52f36