### PR TITLE
Unify validation fixtures

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -32,6 +32,10 @@
 - Added Rust Jobs chat and feed links to the generated Jobs section.
 - Updated tests and expected outputs accordingly.
 
+## 2025-07-09
+- Unified Markdown validation tests into a single function.
+
 ## Maintenance
 The development log keeps only the 20 most recent entries.
 When adding a new entry, delete the oldest if there are already 20.
+

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -77,22 +77,23 @@ fn parse_issue_607_full() {
 }
 
 #[test]
-fn validate_generated_posts() {
-    let input = include_str!("2025-06-25-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string()).unwrap();
-    assert!(!posts.is_empty());
-    for post in &posts {
-        common::assert_valid_markdown(post);
-    }
-}
+fn validate_fixture_posts() {
+    let fixtures = [
+        include_str!("2025-06-25-this-week-in-rust.md"),
+        include_str!("2025-07-02-this-week-in-rust.md"),
+        include_str!("complex.md"),
+    ];
 
-#[test]
-fn validate_issue_606_posts() {
-    let input = include_str!("2025-07-02-this-week-in-rust.md");
-    let posts = generate_posts(input.to_string()).unwrap();
-    assert!(!posts.is_empty());
-    for post in &posts {
-        common::assert_valid_markdown(post);
+    for (idx, input) in fixtures.iter().enumerate() {
+        let posts = generate_posts((*input).to_string()).unwrap();
+        assert!(
+            !posts.is_empty(),
+            "no posts generated for fixture {}",
+            idx + 1
+        );
+        for post in &posts {
+            common::assert_valid_markdown(post);
+        }
     }
 }
 
@@ -102,16 +103,6 @@ fn validate_issue_606_post_4() {
     let posts = generate_posts(input.to_string()).unwrap();
     assert!(posts.len() >= 4);
     common::assert_valid_markdown(&posts[3]);
-}
-
-#[test]
-fn validate_complex_posts() {
-    let input = include_str!("complex.md");
-    let posts = generate_posts(input.to_string()).unwrap();
-    assert!(!posts.is_empty());
-    for post in &posts {
-        common::assert_valid_markdown(post);
-    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- consolidate Markdown validation into one `validate_fixture_posts` test
- document the change in the dev log

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869bd7c8ae48332a0d4aa640b4bb3e9