### PR TITLE
Convert GitHub mentions

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -32,6 +32,10 @@
 - Added Rust Jobs chat and feed links to the generated Jobs section.
 - Updated tests and expected outputs accordingly.
 
+## 2025-07-09
+- GitHub usernames prefixed with `@` are now converted to profile links.
+- Updated parser logic and revised expected test outputs.
+
 ## Maintenance
 The development log keeps only the 20 most recent entries.
 When adding a new entry, delete the oldest if there are already 20.

--- a/tests/expected/606_4.md
+++ b/tests/expected/606_4.md
@@ -4,7 +4,7 @@
 • [salsa idiomize VariantFields query](https://github.com/rust-lang/rust-analyzer/pull/20106)
 **Rust Compiler Performance Triage**
 Lots of changes this week with results dominated by the 1\-5% improvements from [\#142941](https://github.com/rust-lang/rust/pull/142941) across lots of primary benchmarks in the suite\.
-Triage done by @simulacrum\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
+Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025/2025-06-30.md)
 **\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**

--- a/tests/expected/607_4.md
+++ b/tests/expected/607_4.md
@@ -4,7 +4,7 @@
 • [salsa idiomize VariantFields query](https://github.com/rust-lang/rust-analyzer/pull/20106)
 **Rust Compiler Performance Triage**
 Lots of changes this week with results dominated by the 1\-5% improvements from [\#142941](https://github.com/rust-lang/rust/pull/142941) across lots of primary benchmarks in the suite\.
-Triage done by @simulacrum\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
+Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025/2025-06-30.md)
 **\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -12,7 +12,7 @@
 • [rust\-analyzer: mimic rustc's new format\_args\! expansion](https://github.com/rust-lang/rust-analyzer/pull/20056)
 **Rust Compiler Performance Triage**
 A week dominated by the landing of a large patch implementing [RFC\#3729](https://github.com/rust-lang/rfcs/pull/3729) which unfortunately introduced rather sizeable performance regressions \(avg of \~1% instruction count on 111 primary benchmarks\)\. This was deemed worth it so that the patch could land and performance could be won back in follow up PRs\.
-Triage done by @rylev\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)
+Triage done by [rylev](https://github.com/rylev)\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)
 Summary:
 | \(instructions:u\)              | mean    | range                 | count |
 | Regressions ❌  \(primary\)      | 1\.1%   | \[0\.2%, 9\.1%\]      | 123   |
@@ -33,4 +33,3 @@ Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final
 • [Allow \#\[must\_use\] on associated types to warn on unused values in generic contexts](https://github.com/rust-lang/rust/pull/142590)
 • [Fix proc\_macro::Ident 's handling of $crate](https://github.com/rust-lang/rust/pull/141996)
 • [Ensure non\-empty buffers for large vectored I/O](https://github.com/rust-lang/rust/pull/138879)
-• [Rust RFCs](https://github.com/rust-lang/rfcs/labels/final-comment-period)

--- a/tests/expected/expected5.md
+++ b/tests/expected/expected5.md
@@ -1,4 +1,5 @@
 *Part 5/6*
+• [Rust RFCs](https://github.com/rust-lang/rfcs/labels/final-comment-period)
 • [RFC: \-\-crate\-attr](https://github.com/rust-lang/rfcs/pull/3791)
 No Items entered Final Comment Period this week for [Cargo](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.
 Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.


### PR DESCRIPTION
## Summary
- convert `@username` patterns into GitHub profile links
- update expected outputs for new formatting
- document new feature in `DEVLOG`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869babc42f4833283a5206d1f0fbe32