### PR TITLE
Fix Telegram pin response parsing

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -40,3 +40,7 @@
 ## Maintenance
 The development log keeps only the 20 most recent entries.
 When adding a new entry, delete the oldest if there are already 20.
+
+## 2025-07-10
+- Fixed parsing of pinChatMessage response handling boolean result.
+- Updated integration test accordingly.

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -540,7 +540,8 @@ pub fn send_to_telegram(
             let status = resp.status();
             let body = resp.text()?;
             debug!("Telegram pin response {status}: {body}");
-            let pin_data: TelegramResponse<()> = serde_json::from_str(&body)
+            use serde::de::IgnoredAny;
+            let pin_data: TelegramResponse<IgnoredAny> = serde_json::from_str(&body)
                 .map_err(|e| format!("Failed to parse Telegram pin response: {e}: {body}"))?;
             if !pin_data.ok {
                 error!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -67,7 +67,7 @@ fn telegram_request_sent() {
             Matcher::UrlEncoded("disable_web_page_preview".into(), "true".into()),
         ]))
         .with_status(200)
-        .with_body("{\"ok\":true}")
+        .with_body("{\"ok\":true,\"result\":true}")
         .expect(1)
         .create();
 
@@ -142,7 +142,7 @@ fn telegram_request_sent_plain() {
                 && !body.contains("parse_mode")
         })
         .with_status(200)
-        .with_body("{\"ok\":true}")
+        .with_body("{\"ok\":true,\"result\":true}")
         .expect(1)
         .create();
 
@@ -178,7 +178,7 @@ fn sends_valid_markdown() {
             Matcher::UrlEncoded("disable_web_page_preview".into(), "true".into()),
         ]))
         .with_status(200)
-        .with_body("{\"ok\":true}")
+        .with_body("{\"ok\":true,\"result\":true}")
         .expect(1)
         .create();
 
@@ -305,7 +305,7 @@ fn pin_first_message() {
             Matcher::UrlEncoded("message_id".into(), "1".into()),
         ]))
         .with_status(200)
-        .with_body("{\"ok\":true}")
+        .with_body("{\"ok\":true,\"result\":true}")
         .expect(1)
         .create();
 


### PR DESCRIPTION
## Summary
- handle boolean values in `pinChatMessage` responses
- adjust integration test to expect `result: true`
- document the fix in `DEVLOG.md`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6869be4b14ac8332b6094dca3bcc023e