### PR TITLE
Fix deleteMessage parsing

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -572,7 +572,7 @@ pub fn send_to_telegram(
             let status = resp.status();
             let body = resp.text()?;
             debug!("Telegram delete response {status}: {body}");
-            let delete_data: TelegramResponse<()> = serde_json::from_str(&body)
+            let delete_data: TelegramResponse<IgnoredAny> = serde_json::from_str(&body)
                 .map_err(|e| format!("Failed to parse Telegram delete response: {e}: {body}"))?;
             if !delete_data.ok {
                 warn!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -239,7 +239,7 @@ fn send_issue_606_post_4() {
             Matcher::UrlEncoded("disable_web_page_preview".into(), "true".into()),
         ]))
         .with_status(200)
-        .with_body("{\"ok\":true}")
+        .with_body("{\"ok\":true,\"result\":true}")
         .expect(1)
         .create();
 
@@ -296,7 +296,7 @@ fn pin_first_message() {
             Matcher::UrlEncoded("message_id".into(), "2".into()),
         ]))
         .with_status(200)
-        .with_body("{\"ok\":true}")
+        .with_body("{\"ok\":true,\"result\":true}")
         .expect(1)
         .create();
 


### PR DESCRIPTION
## Summary
- use `IgnoredAny` when reading deleteMessage response
- adjust pin_first_message mock to return `{"ok":true,"result":true}`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869c8f369dc8332ac46ea627cce22f7