### PR TITLE
Add custom Cargo profiles

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,16 @@ path = "src/lib.rs"
 [[bin]]
 name = "check-docs"
 path = "src/bin/check_docs.rs"
+
+[profile.dev]
+opt-level = 0
+incremental = true
+
+[profile.test]
+opt-level = 0
+incremental = true
+
+[profile.release]
+opt-level = 1
+incremental = true
+codegen-units = 16

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Set `RUST_LOG=info` to see detailed logs including Telegram API responses:
 RUST_LOG=info cargo run --bin twir-deploy-notify -- twir/content/<file-name>.md
 ```
 
+## Cargo profiles
+
+The project defines custom profiles in `Cargo.toml` that optimize for quick
+iteration. Development and test builds use `opt-level = 0` with incremental
+compilation enabled. Release builds set `opt-level = 1`, keep incremental
+compilation, and increase `codegen-units` to `16`.
+
+The `.cargo/config.toml` file adds `-C target-cpu=native` to all builds so local
+compilations target the current machine's CPU features.
+
 ## Configuration
 
 The application expects several environment variables when sending posts to


### PR DESCRIPTION
## Summary
- add build settings under `[profile.*]`
- enable `-C target-cpu=native` for local builds
- document Cargo profiles in README

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869cb7c6d188332bcf609cf70d7ca08