### PR TITLE
Support new subheading styles

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -189,10 +189,12 @@ pub fn format_subheading(title: &str) -> String {
     let lower = trimmed.to_ascii_lowercase();
     if lower == "newsletters" {
         format!("\n**{}:** 📰", escape_markdown(trimmed))
-    } else if lower == "project/tooling updates" {
+    } else if lower == "project/tooling updates" || lower == "compiler" {
         format!("\n**{}:** 🛠️", escape_markdown(trimmed))
     } else if lower == "observations/thoughts" {
         format!("\n**{}:** 🤔", escape_markdown(trimmed))
+    } else if lower == "rust walkthroughs" {
+        format!("\n**{}:** 📚", escape_markdown(trimmed))
     } else {
         format!("**{}**", escape_markdown(trimmed))
     }

--- a/tests/expected/606_1.md
+++ b/tests/expected/606_1.md
@@ -33,7 +33,8 @@
 • \[audio\] [1Password with Andrew Burkhart](https://corrode.dev/podcast/s04e06-1password/)
 • \[audio\] [Dioxus with Jonathan Kelley](https://rustacean-station.org/episode/jonathan-kelley/)
 • \[audio\] [Malachite with Adi Seredinschi](https://rustacean-station.org/episode/adi-seredinschi/)
-**Rust Walkthroughs**
+
+**Rust Walkthroughs:** 📚
 • [Alternative Blanket Implementations for a Single Rust Trait](https://www.greyblake.com/blog/alternative-blanket-implementations-for-single-rust-trait/)
 **Miscellaneous**
 • [Reflections on Haskell and Rust](https://academy.fpblock.com/blog/rust-haskell-reflections/)

--- a/tests/expected/606_3.md
+++ b/tests/expected/606_3.md
@@ -1,7 +1,8 @@
 *Part 3/5*
 📰 **UPDATES FROM THE RUST PROJECT** 📰
 429 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-24..2025-07-01)
-**Compiler**
+
+**Compiler:** 🛠️
 • [add \#\[loop\_match\] for improved DFA codegen](https://github.com/rust-lang/rust/pull/138780)
 • [add runtime check to avoid overwrite arg in Diag](https://github.com/rust-lang/rust/pull/142724)
 • [check CoerceUnsized impl validity before coercing](https://github.com/rust-lang/rust/pull/142976)
@@ -41,4 +42,3 @@
 • [highlighting of return values while the cursor is on match / if / \=\>](https://github.com/rust-lang/rust-analyzer/pull/19546)
 • [fix completion in when typing integer\.\|](https://github.com/rust-lang/rust-analyzer/pull/20110)
 • [prettify AST in PathTransform if it's coming from a macro](https://github.com/rust-lang/rust-analyzer/pull/20103)
-• [parse new const trait syntax](https://github.com/rust-lang/rust-analyzer/pull/20105)

--- a/tests/expected/606_4.md
+++ b/tests/expected/606_4.md
@@ -1,4 +1,5 @@
 *Part 4/5*
+• [parse new const trait syntax](https://github.com/rust-lang/rust-analyzer/pull/20105)
 • [remove last use of rustc\_pattern\_analysis::Captures](https://github.com/rust-lang/rust-analyzer/pull/20124)
 • [remove unnecessary parens in closure](https://github.com/rust-lang/rust-analyzer/pull/20122)
 • [salsa idiomize VariantFields query](https://github.com/rust-lang/rust-analyzer/pull/20106)

--- a/tests/expected/607_1.md
+++ b/tests/expected/607_1.md
@@ -33,7 +33,8 @@
 • \[audio\] [1Password with Andrew Burkhart](https://corrode.dev/podcast/s04e06-1password/)
 • \[audio\] [Dioxus with Jonathan Kelley](https://rustacean-station.org/episode/jonathan-kelley/)
 • \[audio\] [Malachite with Adi Seredinschi](https://rustacean-station.org/episode/adi-seredinschi/)
-**Rust Walkthroughs**
+
+**Rust Walkthroughs:** 📚
 • [Alternative Blanket Implementations for a Single Rust Trait](https://www.greyblake.com/blog/alternative-blanket-implementations-for-single-rust-trait/)
 **Miscellaneous**
 • [Reflections on Haskell and Rust](https://academy.fpblock.com/blog/rust-haskell-reflections/)

--- a/tests/expected/607_3.md
+++ b/tests/expected/607_3.md
@@ -1,7 +1,8 @@
 *Part 3/5*
 📰 **UPDATES FROM THE RUST PROJECT** 📰
 429 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-24..2025-07-01)
-**Compiler**
+
+**Compiler:** 🛠️
 • [add \#\[loop\_match\] for improved DFA codegen](https://github.com/rust-lang/rust/pull/138780)
 • [add runtime check to avoid overwrite arg in Diag](https://github.com/rust-lang/rust/pull/142724)
 • [check CoerceUnsized impl validity before coercing](https://github.com/rust-lang/rust/pull/142976)
@@ -41,4 +42,3 @@
 • [highlighting of return values while the cursor is on match / if / \=\>](https://github.com/rust-lang/rust-analyzer/pull/19546)
 • [fix completion in when typing integer\.\|](https://github.com/rust-lang/rust-analyzer/pull/20110)
 • [prettify AST in PathTransform if it's coming from a macro](https://github.com/rust-lang/rust-analyzer/pull/20103)
-• [parse new const trait syntax](https://github.com/rust-lang/rust-analyzer/pull/20105)

--- a/tests/expected/607_4.md
+++ b/tests/expected/607_4.md
@@ -1,4 +1,5 @@
 *Part 4/5*
+• [parse new const trait syntax](https://github.com/rust-lang/rust-analyzer/pull/20105)
 • [remove last use of rustc\_pattern\_analysis::Captures](https://github.com/rust-lang/rust-analyzer/pull/20124)
 • [remove unnecessary parens in closure](https://github.com/rust-lang/rust-analyzer/pull/20122)
 • [salsa idiomize VariantFields query](https://github.com/rust-lang/rust-analyzer/pull/20106)

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -24,7 +24,8 @@
 • [Defending Democracies With Rust](https://filtra.io/rust/interviews/helsing-jun-25)
 • [Rust: A language that grows with you, your career and your projects](https://kerkour.com/rust-grows-with-you)
 • \[video playlist\] [Scientific Computing in Rust 2025](https://www.youtube.com/watch?v=XyXMKuclTcQ&list=PLrueqeouhcZNRW7H26DfscFjGSf0Pzd8c)
-**Rust Walkthroughs**
+
+**Rust Walkthroughs:** 📚
 • [Porting GPU shaders to Rust 30x faster with AI](https://rust-gpu.github.io/blog/2025/06/24/vulkan-shader-port/)
 • [Bitwise DNA Compression in Rust: Small Footprint with Fast Reverse Complements](https://arianfarid.me/articles/dna-compression.html)
 • [Writing a basic Linux device driver when you know nothing about Linux drivers or USB](https://crescentro.se/posts/writing-drivers/)

--- a/tests/expected/expected3.md
+++ b/tests/expected/expected3.md
@@ -1,7 +1,8 @@
 *Part 3/6*
 📰 **UPDATES FROM THE RUST PROJECT** 📰
 448 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-17..2025-06-24)
-**Compiler**
+
+**Compiler:** 🛠️
 • [perf: Cache the canonical instantiation of param\-envs](https://github.com/rust-lang/rust/pull/142316)
 • [asyncDrop trait without sync Drop generates an error](https://github.com/rust-lang/rust/pull/142606)
 • [stabilize generic\_arg\_infer](https://github.com/rust-lang/rust/pull/141610)


### PR DESCRIPTION
## Summary
- add `compiler` and `rust walkthroughs` handling in `format_subheading`
- update expected outputs with new heading forms and adjusted message splits

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6869d1db69ec8332bd589d63d4e1114f