### PR TITLE
fix: spacing before section headings

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -416,6 +416,9 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
             section_text.push_str(&header);
         }
         if !sec.title.is_empty() {
+            if idx > 0 {
+                section_text.push('\n');
+            }
             section_text.push_str(&format!("{}\n", format_heading(&sec.title)));
         }
         for line in &sec.lines {

--- a/tests/expected/606_1.md
+++ b/tests/expected/606_1.md
@@ -37,6 +37,7 @@
 • [Alternative Blanket Implementations for a Single Rust Trait](https://www.greyblake.com/blog/alternative-blanket-implementations-for-single-rust-trait/)
 **Miscellaneous**
 • [Reflections on Haskell and Rust](https://academy.fpblock.com/blog/rust-haskell-reflections/)
+
 📦 **CRATE OF THE WEEK** 📦
 This week's crate is [ansic](https://crates.io/crates/ansic), a proc macro providing a DSL to output ANSI escape strings with zero runtime overhead\.
 Thanks to [Zeon](https://users.rust-lang.org/t/crate-of-the-week/2704/1448) for the self\-suggestion\!

--- a/tests/expected/606_2.md
+++ b/tests/expected/606_2.md
@@ -1,9 +1,11 @@
 *Part 2/5*
+
 📰 **CALLS FOR TESTING** 📰
 An important step for RFC implementation is for people to experiment with the implementation and give feedback, especially before stabilization\.
 If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 • No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.
 [Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list\.
+
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
 Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!

--- a/tests/expected/606_5.md
+++ b/tests/expected/606_5.md
@@ -1,4 +1,5 @@
 *Part 5/5*
+
 📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
 💼 [Rust Jobs chat](https://t.me/rust_jobs)

--- a/tests/expected/607_1.md
+++ b/tests/expected/607_1.md
@@ -37,6 +37,7 @@
 • [Alternative Blanket Implementations for a Single Rust Trait](https://www.greyblake.com/blog/alternative-blanket-implementations-for-single-rust-trait/)
 **Miscellaneous**
 • [Reflections on Haskell and Rust](https://academy.fpblock.com/blog/rust-haskell-reflections/)
+
 📦 **CRATE OF THE WEEK** 📦
 This week's crate is [ansic](https://crates.io/crates/ansic), a proc macro providing a DSL to output ANSI escape strings with zero runtime overhead\.
 Thanks to [Zeon](https://users.rust-lang.org/t/crate-of-the-week/2704/1448) for the self\-suggestion\!

--- a/tests/expected/607_2.md
+++ b/tests/expected/607_2.md
@@ -1,9 +1,11 @@
 *Part 2/5*
+
 📰 **CALLS FOR TESTING** 📰
 An important step for RFC implementation is for people to experiment with the implementation and give feedback, especially before stabilization\.
 If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 • No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.
 [Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list\.
+
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
 Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!

--- a/tests/expected/607_5.md
+++ b/tests/expected/607_5.md
@@ -1,4 +1,5 @@
 *Part 5/5*
+
 📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
 💼 [Rust Jobs chat](https://t.me/rust_jobs)

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -7,17 +7,20 @@
     • Sub Sub Item 1
       • Deep Item
 • Item 2
+
 📰 **QUOTE BLOCK** 📰
 \> First level quote line 1 First level quote line 2
 \> Nested quote line
 
 Back to first level
+
 📰 **CODE BLOCK** 📰
 ```
 fn greet\(\) \{
     println\!\("Hello, world\!"\);
 \}
 ```
+
 📰 **TABLE EXAMPLE** 📰
 | Short | Much Longer Column | C  |
 | 1     | a                  | 3  |

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -30,6 +30,7 @@
 • [Writing a basic Linux device driver when you know nothing about Linux drivers or USB](https://crescentro.se/posts/writing-drivers/)
 • [Rewriting Kafka in Rust Async: Insights and Lessons Learned in Rust](https://wangjunfei.com/2025/06/18/Rewriting-Kafka-in-Rust-Async-Insights-and-Lessons-Learned/)
 • [The Complete Rust Security Handbook](https://yevh.github.io/rust-security-handbook/)
+
 📦 **CRATE OF THE WEEK** 📦
 This week's crate is [primitive\_fixed\_point\_decimal](https://docs.rs/primitive_fixed_point_decimal), a crate of real fixed\-point decimal types\.
 Thanks to [Wu Bingzheng](https://users.rust-lang.org/t/crate-of-the-week/2704/1445) for the self\-suggestion\!

--- a/tests/expected/expected2.md
+++ b/tests/expected/expected2.md
@@ -1,4 +1,5 @@
 *Part 2/6*
+
 📰 **CALLS FOR TESTING** 📰
 An important step for RFC implementation is for people to experiment with the implementation and give feedback, especially before stabilization\.
 If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
@@ -8,6 +9,7 @@ If you are a feature implementer and would like your RFC to appear in this list,
 **\[Rust\]\(https://github\.com/rust\-lang/rust/labels/call\-for\-testing\)**
 **\[Rustup\]\(https://github\.com/rust\-lang/rustup/labels/call\-for\-testing\)**
 If you are a feature implementer and would like your RFC to appear on the above list, add the new call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
+
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
 Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!

--- a/tests/expected/expected6.md
+++ b/tests/expected/expected6.md
@@ -1,4 +1,5 @@
 *Part 6/6*
+
 📰 **JOBS** 📰
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1knkfb6/official_rrust_whos_hiring_thread_for_jobseekers/)
 💼 [Rust Jobs chat](https://t.me/rust_jobs)


### PR DESCRIPTION
## Summary
- insert newline before non-first section headings
- adjust expected fixtures for added blank lines

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869d1b502dc8332999b7d803c431a57