### PR TITLE
Добавить тип ошибки MarkdownError

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -530,7 +530,7 @@ pub fn send_to_telegram(
         debug!("Posting message {} to {}", i + 1, url);
         let mut form = vec![("chat_id", chat_id), ("text", post)];
         if use_markdown {
-            validate_telegram_markdown(post).map_err(ValidationError)?;
+            validate_telegram_markdown(post).map_err(|e| ValidationError(e.to_string()))?;
             form.push(("parse_mode", "MarkdownV2"));
         }
         form.push(("disable_web_page_preview", "true"));


### PR DESCRIPTION
## Summary
- introduce enum `MarkdownError` to classify markdown validation issues
- return new error type from `validate_telegram_markdown`
- adapt generator to display these errors

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6869d6e7c8008332a4090e8a69eddf15