### PR TITLE
Validate Telegram markdown before sending

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -518,6 +518,13 @@ pub fn send_to_telegram(
     use_markdown: bool,
     pin_first: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if use_markdown {
+        for (i, post) in posts.iter().enumerate() {
+            validate_telegram_markdown(post)
+                .map_err(|e| ValidationError(format!("Post {} invalid: {e}", i + 1)))?;
+        }
+    }
+
     let client = Client::new();
     info!("Sending {} posts", posts.len());
     let mut first_id: Option<i64> = None;
@@ -530,7 +537,6 @@ pub fn send_to_telegram(
         debug!("Posting message {} to {}", i + 1, url);
         let mut form = vec![("chat_id", chat_id), ("text", post)];
         if use_markdown {
-            validate_telegram_markdown(post).map_err(ValidationError)?;
             form.push(("parse_mode", "MarkdownV2"));
         }
         form.push(("disable_web_page_preview", "true"));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -557,3 +557,17 @@ fn jobs_links_present() {
     assert!(combined.contains("[Rust Jobs chat](https://t.me/rust_jobs)"));
     assert!(combined.contains("[Rust Jobs feed](https://t.me/rust_jobs_feed)"));
 }
+
+#[test]
+fn send_to_telegram_rejects_invalid_before_request() {
+    let posts = vec!["bad *text".to_string()];
+    let mut server = mockito::Server::new();
+    let m = server
+        .mock("POST", "/botTEST/sendMessage")
+        .expect(0)
+        .create();
+
+    let result = generator::send_to_telegram(&posts, &server.url(), "TEST", "42", true, false);
+    assert!(result.is_err());
+    m.assert();
+}


### PR DESCRIPTION
## Summary
- check all posts for Telegram Markdown validity before sending
- remove per-post validation in loop
- add integration test to ensure invalid Markdown results in no HTTP call

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6869d6e192d48332814a35e6d3333fc5