### PR TITLE
Добавить эмодзи для подзаголовков

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -401,7 +401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1036,7 +1036,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.9.1",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1108,6 +1108,48 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -1218,7 +1260,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand",
+ "rand 0.9.1",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1262,12 +1304,21 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1277,8 +1328,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1295,7 +1352,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1428,7 +1485,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1584,6 +1641,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -1763,7 +1826,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1888,6 +1951,7 @@ dependencies = [
  "log",
  "mockito",
  "once_cell",
+ "phf",
  "proptest",
  "pulldown-cmark",
  "regex",
@@ -2119,7 +2183,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"
 walkdir = "2"
+phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,4 +1,5 @@
 use log::{debug, error, info, warn};
+use phf::phf_map;
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::{fs, path::Path, thread, time::Duration};
@@ -9,6 +10,22 @@ use crate::validator::validate_telegram_markdown;
 
 pub const TELEGRAM_LIMIT: usize = 4000;
 pub const TELEGRAM_DELAY_MS: u64 = 1000;
+
+/// Mapping of subheading titles to emojis used in Telegram posts.
+pub static SUBHEADING_EMOJIS: phf::Map<&'static str, &'static str> = phf_map! {
+    "newsletters" => "📰",
+    "project/tooling updates" => "🛠️",
+    "compiler" => "🛠️",
+    "observations/thoughts" => "🤔",
+    "rust walkthroughs" => "📚",
+    "library" => "📚",
+    "cargo" => "📦",
+    "rustdoc" => "📖",
+    "clippy" => "🔧",
+    "rust-analyzer" => "🤖",
+    "tracking issues & prs" => "📌",
+    "quote of the week" => "💬",
+};
 
 /// Short URL guiding contributors how to submit CFP tasks.
 const CFP_GUIDELINES: &str = "https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines";
@@ -187,14 +204,8 @@ pub fn format_heading(title: &str) -> String {
 pub fn format_subheading(title: &str) -> String {
     let trimmed = title.trim();
     let lower = trimmed.to_ascii_lowercase();
-    if lower == "newsletters" {
-        format!("\n**{}:** 📰", escape_markdown(trimmed))
-    } else if lower == "project/tooling updates" || lower == "compiler" {
-        format!("\n**{}:** 🛠️", escape_markdown(trimmed))
-    } else if lower == "observations/thoughts" {
-        format!("\n**{}:** 🤔", escape_markdown(trimmed))
-    } else if lower == "rust walkthroughs" {
-        format!("\n**{}:** 📚", escape_markdown(trimmed))
+    if let Some(emoji) = SUBHEADING_EMOJIS.get(lower.as_str()) {
+        format!("\n**{}:** {}", escape_markdown(trimmed), emoji)
     } else {
         format!("**{}**", escape_markdown(trimmed))
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -90,7 +90,10 @@ pub fn parse_sections(text: &str) -> Vec<Section> {
                         sections.push(sec);
                     }
                     buffer.clear();
-                } else if matches!(level, HeadingLevel::H3 | HeadingLevel::H4) {
+                } else if matches!(
+                    level,
+                    HeadingLevel::H1 | HeadingLevel::H3 | HeadingLevel::H4
+                ) {
                     if let Some(ref mut sec) = current {
                         let line = buffer.trim_end();
                         if !line.is_empty() {
@@ -108,7 +111,10 @@ pub fn parse_sections(text: &str) -> Vec<Section> {
                         lines: Vec::new(),
                     });
                     buffer.clear();
-                } else if matches!(level, HeadingLevel::H3 | HeadingLevel::H4) {
+                } else if matches!(
+                    level,
+                    HeadingLevel::H1 | HeadingLevel::H3 | HeadingLevel::H4
+                ) {
                     if let Some(ref mut sec) = current {
                         let heading = buffer.trim();
                         if !heading.is_empty() {

--- a/tests/expected/606_3.md
+++ b/tests/expected/606_3.md
@@ -17,25 +17,30 @@
 • [only compute recursive callees once](https://github.com/rust-lang/rust/pull/142625)
 • [shallowly bail from coerce\_unsized more](https://github.com/rust-lang/rust/pull/142941)
 • [simplify ObligationCauseCode::IfExpression](https://github.com/rust-lang/rust/pull/139594)
-**Library**
+
+**Library:** 📚
 • [add SIMD funnel shift and round\-to\-even intrinsics](https://github.com/rust-lang/rust/pull/142078)
 • [make RefCell unstably const](https://github.com/rust-lang/rust/pull/137843)
 • [make Sub, Mul, Div and Rem const\_traits](https://github.com/rust-lang/rust/pull/143000)
-**Cargo**
+
+**Cargo:** 📦
 • [add http\.proxy\-cainfo config for proxy certs](https://github.com/rust-lang/cargo/pull/15374)
 • [expand error messages around path dependency on cargo package and cargo publish](https://github.com/rust-lang/cargo/pull/15705)
 • [override Cargo\.lock checksums when doing a dry\-run publish](https://github.com/rust-lang/cargo/pull/15711)
 • [rework cargo\-test\-support & testsuite to use CARGO\_BIN\_EXE\_\* for Cargo](https://github.com/rust-lang/cargo/pull/15692)
-**Rustdoc**
+
+**Rustdoc:** 📖
 • [rustdoc: show attributes on enum variants](https://github.com/rust-lang/rust/pull/142987)
-**Clippy**
+
+**Clippy:** 🔧
 • [missing\_panics\_doc: Allow unwrap\(\) and expect\(\) inside const\-only contexts](https://github.com/rust-lang/rust-clippy/pull/15170)
 • [zero\_ptr: lint in const context as well](https://github.com/rust-lang/rust-clippy/pull/15152)
 • [consider deref'ed argument as non\-temporary](https://github.com/rust-lang/rust-clippy/pull/15172)
 • [cast\_possible\_truncation should not suggest inside const context](https://github.com/rust-lang/rust-clippy/pull/15164)
 • [fix coerce\_container\_to\_any false positive on autoderef](https://github.com/rust-lang/rust-clippy/pull/15057)
 • [fix disallowed\_script\_idents FP on identifiers with \_](https://github.com/rust-lang/rust-clippy/pull/15123)
-**Rust\-Analyzer**
+
+**Rust\-Analyzer:** 🤖
 • [de\-arc trait items query](https://github.com/rust-lang/rust-analyzer/pull/20088)
 • [do not append \-\-compile\-time\-deps to overwritten build script commands](https://github.com/rust-lang/rust-analyzer/pull/20121)
 • [drop rustc workspace loading error, if we don't needs its sources](https://github.com/rust-lang/rust-analyzer/pull/20092)

--- a/tests/expected/606_4.md
+++ b/tests/expected/606_4.md
@@ -13,7 +13,8 @@ Changes to Rust follow the Rust [RFC \(request for comments\) process](https://g
 • No RFCs were approved this week\.
 **Final Comment Period**
 Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs which are reaching a decision\. Express your opinions now\.
-**Tracking Issues & PRs**
+
+**Tracking Issues & PRs:** 📌
 • [Rust](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
 • \[disposition: close\] [Draft: Make into\_parts methods on Vec associated functions](https://github.com/rust-lang/rust/pull/141509)
 • [Implement Debug for EncodeWide](https://github.com/rust-lang/rust/pull/140153)

--- a/tests/expected/606_5.md
+++ b/tests/expected/606_5.md
@@ -4,7 +4,8 @@
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
 💼 [Rust Jobs chat](https://t.me/rust_jobs)
 📢 [Rust Jobs feed](https://t.me/rust_jobs_feed)
-Quote of the Week
+
+**Quote of the Week:** 💬
 \> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
 And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\.
 

--- a/tests/expected/607_3.md
+++ b/tests/expected/607_3.md
@@ -17,25 +17,30 @@
 • [only compute recursive callees once](https://github.com/rust-lang/rust/pull/142625)
 • [shallowly bail from coerce\_unsized more](https://github.com/rust-lang/rust/pull/142941)
 • [simplify ObligationCauseCode::IfExpression](https://github.com/rust-lang/rust/pull/139594)
-**Library**
+
+**Library:** 📚
 • [add SIMD funnel shift and round\-to\-even intrinsics](https://github.com/rust-lang/rust/pull/142078)
 • [make RefCell unstably const](https://github.com/rust-lang/rust/pull/137843)
 • [make Sub, Mul, Div and Rem const\_traits](https://github.com/rust-lang/rust/pull/143000)
-**Cargo**
+
+**Cargo:** 📦
 • [add http\.proxy\-cainfo config for proxy certs](https://github.com/rust-lang/cargo/pull/15374)
 • [expand error messages around path dependency on cargo package and cargo publish](https://github.com/rust-lang/cargo/pull/15705)
 • [override Cargo\.lock checksums when doing a dry\-run publish](https://github.com/rust-lang/cargo/pull/15711)
 • [rework cargo\-test\-support & testsuite to use CARGO\_BIN\_EXE\_\* for Cargo](https://github.com/rust-lang/cargo/pull/15692)
-**Rustdoc**
+
+**Rustdoc:** 📖
 • [rustdoc: show attributes on enum variants](https://github.com/rust-lang/rust/pull/142987)
-**Clippy**
+
+**Clippy:** 🔧
 • [missing\_panics\_doc: Allow unwrap\(\) and expect\(\) inside const\-only contexts](https://github.com/rust-lang/rust-clippy/pull/15170)
 • [zero\_ptr: lint in const context as well](https://github.com/rust-lang/rust-clippy/pull/15152)
 • [consider deref'ed argument as non\-temporary](https://github.com/rust-lang/rust-clippy/pull/15172)
 • [cast\_possible\_truncation should not suggest inside const context](https://github.com/rust-lang/rust-clippy/pull/15164)
 • [fix coerce\_container\_to\_any false positive on autoderef](https://github.com/rust-lang/rust-clippy/pull/15057)
 • [fix disallowed\_script\_idents FP on identifiers with \_](https://github.com/rust-lang/rust-clippy/pull/15123)
-**Rust\-Analyzer**
+
+**Rust\-Analyzer:** 🤖
 • [de\-arc trait items query](https://github.com/rust-lang/rust-analyzer/pull/20088)
 • [do not append \-\-compile\-time\-deps to overwritten build script commands](https://github.com/rust-lang/rust-analyzer/pull/20121)
 • [drop rustc workspace loading error, if we don't needs its sources](https://github.com/rust-lang/rust-analyzer/pull/20092)

--- a/tests/expected/607_4.md
+++ b/tests/expected/607_4.md
@@ -13,7 +13,8 @@ Changes to Rust follow the Rust [RFC \(request for comments\) process](https://g
 • No RFCs were approved this week\.
 **Final Comment Period**
 Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs which are reaching a decision\. Express your opinions now\.
-**Tracking Issues & PRs**
+
+**Tracking Issues & PRs:** 📌
 • [Rust](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
 • \[disposition: close\] [Draft: Make into\_parts methods on Vec associated functions](https://github.com/rust-lang/rust/pull/141509)
 • [Implement Debug for EncodeWide](https://github.com/rust-lang/rust/pull/140153)

--- a/tests/expected/607_5.md
+++ b/tests/expected/607_5.md
@@ -4,7 +4,8 @@
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1llcso7/official_rrust_whos_hiring_thread_for_jobseekers/)
 💼 [Rust Jobs chat](https://t.me/rust_jobs)
 📢 [Rust Jobs feed](https://t.me/rust_jobs_feed)
-Quote of the Week
+
+**Quote of the Week:** 💬
 \> I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\.
 And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\.
 

--- a/tests/expected/expected3.md
+++ b/tests/expected/expected3.md
@@ -7,7 +7,8 @@
 • [asyncDrop trait without sync Drop generates an error](https://github.com/rust-lang/rust/pull/142606)
 • [stabilize generic\_arg\_infer](https://github.com/rust-lang/rust/pull/141610)
 • [skip no\-op drop glue](https://github.com/rust-lang/rust/pull/142508)
-**Library**
+
+**Library:** 📚
 • [add trim\_prefix and trim\_suffix methods for both slice and str types](https://github.com/rust-lang/rust/pull/142331)
 • [allow comparisons between CStr, CString, and Cow<CStr\>](https://github.com/rust-lang/rust/pull/137268)
 • [allow storing format\_args\!\(\) in variable](https://github.com/rust-lang/rust/pull/140748)
@@ -16,15 +17,18 @@
 • [let String pass \#\[track\_caller\] to its Vec calls](https://github.com/rust-lang/rust/pull/142728)
 • [safer implementation of RepeatN](https://github.com/rust-lang/rust/pull/130887)
 • [use a distinct ToString implementation for u128 and i128](https://github.com/rust-lang/rust/pull/142294)
-**Cargo**
+
+**Cargo:** 📦
 • [cargo: feat\(toml\): Parse support for multiple build scripts](https://github.com/rust-lang/cargo/pull/15630)
 • [cargo: feat: introduce perma unstable \-\-compile\-time\-deps option for cargo build](https://github.com/rust-lang/cargo/pull/15674)
 • [cargo: fix potential deadlock in CacheState::lock](https://github.com/rust-lang/cargo/pull/15698)
-**Rustdoc**
+
+**Rustdoc:** 📖
 • [avoid a few more allocations in write\_shared\.rs](https://github.com/rust-lang/rust/pull/142667)
 • [rustdoc\-json: keep empty generic args if parenthesized](https://github.com/rust-lang/rust/pull/142932)
 • [rustdoc: make srcIndex no longer a global variable](https://github.com/rust-lang/rust/pull/142100)
-**Clippy**
+
+**Clippy:** 🔧
 • [use jemalloc for Clippy](https://github.com/rust-lang/rust/pull/142286)
 • [perf: Don't spawn so many compilers \(3/2\) \(19m → 250k\)](https://github.com/rust-lang/rust-clippy/pull/15030)
 • [Sugg: do not parenthesize a double unary operator](https://github.com/rust-lang/rust-clippy/pull/14983)
@@ -41,4 +45,5 @@
 • [fix false positive of borrow\_deref\_ref](https://github.com/rust-lang/rust-clippy/pull/14967)
 • [fix suggestion\-causes\-error of empty\_line\_after\_outer\_attr](https://github.com/rust-lang/rust-clippy/pull/15078)
 • [new lint: manual\_is\_multiple\_of](https://github.com/rust-lang/rust-clippy/pull/14292)
-**Rust\-Analyzer**
+
+**Rust\-Analyzer:** 🤖

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -27,7 +27,8 @@ Changes to Rust follow the Rust [RFC \(request for comments\) process](https://g
 • No RFCs were approved this week\.
 **Final Comment Period**
 Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs which are reaching a decision\. Express your opinions now\.
-**Tracking Issues & PRs**
+
+**Tracking Issues & PRs:** 📌
 • [Rust](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)
 • [Use lld by default on x86\_64\-unknown\-linux\-gnu stable](https://github.com/rust-lang/rust/pull/140525)
 • [Allow \#\[must\_use\] on associated types to warn on unused values in generic contexts](https://github.com/rust-lang/rust/pull/142590)

--- a/tests/expected/expected6.md
+++ b/tests/expected/expected6.md
@@ -4,7 +4,8 @@
 Please see the latest [Who's Hiring thread on r/rust](https://www.reddit.com/r/rust/comments/1knkfb6/official_rrust_whos_hiring_thread_for_jobseekers/)
 💼 [Rust Jobs chat](https://t.me/rust_jobs)
 📢 [Rust Jobs feed](https://t.me/rust_jobs_feed)
-Quote of the Week
+
+**Quote of the Week:** 💬
 \> Our experience is that no matter how many safeguards you put on code, there’s no cure\-all that prevents bad programming\. Of course, to take the contrary argument, seat belts don’t stop all traffic fatalities, but you could just choose not to have accidents\. So we do have seat belts\. If Rust can prevent some mistakes or malicious intent, maybe it’s worth it even if it isn’t perfect\.
 
 – [Al Williams on hackaday](https://hackaday.com/2025/06/21/if-your-kernel-development-is-a-little-rusty/)


### PR DESCRIPTION
## Summary
- introduce `SUBHEADING_EMOJIS` for predefined subheadings
- rework `format_subheading` to use the map
- treat H1 like other subheadings in the parser
- refresh expected test output files
- include new `phf` dependency

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869d9319b8483329e96631369b91686