### PR TITLE
Добавить шаблон коммитов

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,6 @@
+# Commit message template
+# Provide a short summary in imperative mood.
+# Leave a blank line after the summary and wrap lines at 72 characters.
+# Describe the motivation and changes in the body if necessary.
+# Append the following trailer for AI-generated contributions.
+Co-authored-by: Codex Agent <email@example.com>

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ original task description and create a new task based on the latest commit. A
 prompt appears asking whether to launch the task in a clean environment. See
 [RESTART.md](RESTART.md) for details.
 
+## Commit message template
+
+Git can automatically include the required co-author line in every commit. Set
+the template once using:
+
+```bash
+git config commit.template .gitmessage
+```
+
+Adjust the agent name or email by editing `.gitmessage` directly or by setting
+`GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` before committing.
+
 ## License
 
 This project is distributed under two licenses: the standard MIT terms in `LICENSE` and the "QQRM LAPOCHKA v1.0 License (AI-first Vibecoder)" in `LICENSE_QQRM_LAPOCHKA`.


### PR DESCRIPTION
## Summary
- add `.gitmessage` with commit message hints
- document usage of `.gitmessage` in README

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869e2c011fc8332a2b85f541b2fcdb7