### PR TITLE
Update CFP section filtering

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -50,6 +50,12 @@ fn simplify_cfp_section(section: &mut Section) {
         if line.contains("guidelines") && line.contains("submit tasks") {
             continue;
         }
+        if line.starts_with("Always wanted to contribute")
+            || line.starts_with("Some of these tasks")
+            || line.starts_with("Are you a new or experienced speaker")
+        {
+            continue;
+        }
         if in_projects {
             if line.trim() == "No Calls for participation were submitted this week." {
                 continue;
@@ -825,6 +831,19 @@ mod tests {
         let posts = vec!["bad *text".to_string()];
         let err = send_to_telegram(&posts, "http://example.com", "TOKEN", "42", true, false);
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn cfp_sections_without_content_are_short() {
+        let input = include_str!("../tests/2025-07-05-call-for-participation.md");
+        let posts = generate_posts(input.to_string()).unwrap();
+        assert_eq!(posts.len(), 1);
+        let post = &posts[0];
+        assert!(post.contains("No Calls for participation were submitted this week"));
+        assert!(post.contains("No Calls for papers or presentations were submitted this week"));
+        assert!(!post.contains("Always wanted to contribute"));
+        assert!(!post.contains("Some of these tasks"));
+        assert!(!post.contains("Are you a new or experienced speaker"));
     }
 
     mod property {

--- a/tests/expected/606_2.md
+++ b/tests/expected/606_2.md
@@ -8,11 +8,8 @@ If you are a feature implementer and would like your RFC to appear in this list,
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
-Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
-Some of these tasks may also have mentors available, visit the task page for more information\.
 No Calls for participation were submitted this week\.
 **CFP \- Events**
-Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker\.
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
 На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines)

--- a/tests/expected/607_2.md
+++ b/tests/expected/607_2.md
@@ -8,11 +8,8 @@ If you are a feature implementer and would like your RFC to appear in this list,
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
-Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
-Some of these tasks may also have mentors available, visit the task page for more information\.
 No Calls for participation were submitted this week\.
 **CFP \- Events**
-Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker\.
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
 На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines)

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -3,11 +3,8 @@
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
-Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
-Some of these tasks may also have mentors available, visit the task page for more information\.
 No Calls for participation were submitted this week\.
 **CFP \- Events**
-Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker\.
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
 На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines)

--- a/tests/expected/expected2.md
+++ b/tests/expected/expected2.md
@@ -12,14 +12,11 @@ If you are a feature implementer and would like your RFC to appear on the above 
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**
-Always wanted to contribute to open\-source projects but did not know where to start? Every week we highlight some tasks from the Rust community for you to pick and get started\!
-Some of these tasks may also have mentors available, visit the task page for more information\.
 • [Continuwuity \- Default room ACLs](https://forgejo.ellis.link/continuwuation/continuwuity/issues/775)
 • [Continuwuity \- Ability to entirely disable typing and read receipts](https://forgejo.ellis.link/continuwuation/continuwuity/issues/821)
 • [Continuwuity \- bug: appservice users are not created on registration](https://forgejo.ellis.link/continuwuation/continuwuity/issues/813)
 • [Continuwuity \- Invite filtering / disable invites per account](https://forgejo.ellis.link/continuwuation/continuwuity/issues/836)
 **CFP \- Events**
-Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker\.
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
 На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines)


### PR DESCRIPTION
## Summary
- skip contributor intro sentences in CFP sections
- skip intro sentence in CFP events
- regenerate expected outputs
- add test for empty CFP sections

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6869e21c60d08332aa1ea66f0eae2c00