### PR TITLE
Add verify-posts step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,21 +42,45 @@ jobs:
           toolchain: 1.88.0
           profile: minimal
 
-      - name: Send latest post to Telegram
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ github.event_name == 'workflow_dispatch' && secrets.DEV_TELEGRAM_BOT_TOKEN || secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ github.event_name == 'workflow_dispatch' && secrets.DEV_TELEGRAM_CHAT_ID || secrets.TELEGRAM_CHAT_ID }}
-          TELEGRAM_PIN_FIRST: '1'
+      - name: Determine latest post
+        id: prepare
         run: |
           latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n1)
+          echo "latest_post=$latest_post" >> "$GITHUB_OUTPUT"
           last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
           if [ "$GITHUB_EVENT_NAME" != "schedule" ] || [ "$latest_post" != "$last_sent" ]; then
-            rm -f output_*.md
-            cargo run --quiet --bin twir-deploy-notify -- "$latest_post"
-            echo "$latest_post" > last_sent.txt
+            echo "send=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No new release. Skipping Telegram notification."
+            echo "send=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Send to dev chat
+        if: steps.prepare.outputs.send == 'true'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.DEV_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+          TELEGRAM_PIN_FIRST: '1'
+        run: |
+          rm -f output_*.md
+          cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
+          echo "${{ steps.prepare.outputs.latest_post }}" > last_sent.txt
+
+      - name: Verify dev delivery
+        if: steps.prepare.outputs.send == 'true' && github.event_name == 'schedule'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.DEV_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+        run: |
+          cargo run --quiet --bin verify-posts -- "${{ steps.prepare.outputs.latest_post }}"
+
+      - name: Send to main chat
+        if: steps.prepare.outputs.send == 'true' && github.event_name == 'schedule'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_PIN_FIRST: '1'
+        run: |
+          cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
 
       - name: Upload generated posts
         if: ${{ always() }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,8 @@ This tool processes weekly "This Week in Rust" Markdown files and prepares messa
 - **src/validator.rs**: Checks that generated posts follow Telegram Markdown rules.
 - **Cargo.toml**: Defines dependencies such as `pulldown-cmark`, `regex`, and `teloxide`.
 - **last_sent.txt**: Records the last processed issue for the workflow.
+- **src/bin/verify_posts.rs**: Sends posts to Telegram and confirms that they
+  were delivered correctly.
 
 ## Parsing Flow
 1. The input Markdown includes metadata lines beginning with `Title:`, `Number:`, and `Date:`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ path = "src/lib.rs"
 name = "check-docs"
 path = "src/bin/check_docs.rs"
 
+[[bin]]
+name = "verify-posts"
+path = "src/bin/verify_posts.rs"
+
 [profile.dev]
 opt-level = 0
 incremental = true

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The workflow stores the last processed file in `last_sent.txt` as an artifact an
 
 The Telegram API response is checked with `jq`, and the workflow fails if the server does not return `{ "ok": true }`.
 
+Scheduled runs first send the posts to the development chat using the
+`verify-posts` binary. After the messages are confirmed to appear in the
+channel, the same release is posted to the main chat.
+
 ## Development
 
 Continuous integration runs `cargo machete` to verify that `Cargo.toml` lists only used dependencies. Run this command locally before opening a pull request.

--- a/src/bin/verify_posts.rs
+++ b/src/bin/verify_posts.rs
@@ -1,0 +1,62 @@
+use reqwest::blocking::Client;
+use serde_json::Value;
+use std::{env, fs};
+
+use twir_deploy_notify::generator::{generate_posts, send_to_telegram};
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let path = std::env::args().nth(1).expect("missing input file");
+    let input = fs::read_to_string(path)?;
+    let posts = generate_posts(input).map_err(|e| format!("{e}"))?;
+    let token = env::var("TELEGRAM_BOT_TOKEN")?;
+    let chat_id = env::var("TELEGRAM_CHAT_ID")?;
+    let base =
+        env::var("TELEGRAM_API_BASE").unwrap_or_else(|_| "https://api.telegram.org".to_string());
+    let client = Client::new();
+    let updates_url = format!("{}/bot{}/getUpdates", base.trim_end_matches('/'), token);
+    let resp: Value = client.get(&updates_url).send()?.json()?;
+    let mut last_update = 0i64;
+    if let Some(arr) = resp["result"].as_array() {
+        for upd in arr {
+            if let Some(id) = upd["update_id"].as_i64() {
+                if id > last_update {
+                    last_update = id;
+                }
+            }
+        }
+    }
+    let chat_id_num = chat_id.parse::<i64>().ok();
+    for p in &posts {
+        send_to_telegram(&[p.clone()], &base, &token, &chat_id, true, false)?;
+        let updates_url = format!(
+            "{}/bot{}/getUpdates?offset={}",
+            base.trim_end_matches('/'),
+            token,
+            last_update + 1
+        );
+        let resp: Value = client.get(&updates_url).send()?.json()?;
+        let mut last_text = None;
+        if let Some(arr) = resp["result"].as_array() {
+            for upd in arr {
+                if let Some(id) = upd["update_id"].as_i64() {
+                    if id > last_update {
+                        last_update = id;
+                    }
+                }
+                let msg = upd.get("channel_post").or_else(|| upd.get("message"));
+                if let Some(m) = msg
+                    && (m["chat"]["id"].as_i64() == chat_id_num
+                        || m["chat"]["id"].as_str() == Some(&chat_id))
+                    && let Some(text) = m["text"].as_str()
+                {
+                    last_text = Some(text.to_string());
+                }
+            }
+        }
+        let received = last_text.ok_or("No message from Telegram")?;
+        if &received != p {
+            return Err("Telegram message mismatch".into());
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a helper to verify messages from Telegram
- use verify-posts in the deploy workflow
- document scheduled run behaviour
- mention the new binary in the architecture overview

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)` *(fails: DNS resolution failure)*
- `cargo install cargo-machete --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869e69bf818833287852927b8259d54