### PR TITLE
Handle intro post without pagination

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ This tool processes weekly "This Week in Rust" Markdown files and prepares messa
 
 ## Message Generation
 - Each section becomes a separate Telegram post capped at 4000 characters.
-- Long messages are split by `split_posts`, which scans for escaped characters when breaking lines so that Telegram accepts every chunk. Each post is prefixed with `*Part X/Y*`, where `X` and `Y` are plain digits.
+- Long messages are split by `split_posts`, which scans for escaped characters when breaking lines so that Telegram accepts every chunk. The first post includes the bold title without pagination, while subsequent posts are prefixed with `*Part X/Y*` where `X` and `Y` are plain digits.
 - The optional `--plain` flag removes Markdown formatting for channels that require plain text.
 
 ## Dependencies

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -426,7 +426,7 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
 
     let mut header = String::new();
     if let Some(ref t) = title {
-        header.push_str(&format!("**{}**", escape_markdown(t)));
+        header.push_str(&format!("🦀 **{}**", escape_markdown(t)));
     }
     if let Some(ref n) = number {
         let already_in_title = title.as_ref().map(|t| t.contains(n)).unwrap_or(false);
@@ -483,7 +483,16 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
         if !post.ends_with('\n') {
             post.push('\n');
         }
-        let formatted = format!("*Part {}/{}*\n{}", i + 1, total, post);
+        let formatted = if i == 0 {
+            post.trim_start_matches('\n').to_string()
+        } else {
+            format!(
+                "*Part {}/{}*\n\n{}",
+                i + 1,
+                total,
+                post.trim_start_matches('\n')
+            )
+        };
         validate_telegram_markdown(&formatted)
             .map_err(|e| ValidationError(format!("Generated post {} invalid: {e}", i + 1)))?;
         result.push(formatted);
@@ -689,7 +698,7 @@ mod tests {
         let first = dir.join("output_1.md");
         assert!(first.exists());
         let content = fs::read_to_string(first).unwrap();
-        assert!(content.contains("*Part 1/1*"));
+        assert!(!content.starts_with("*Part"));
         assert!(content.contains("📰 **NEWS** 📰"));
         assert!(content.contains("[Link](https://example.com)"));
         let _ = fs::remove_dir_all(&dir);

--- a/tests/expected/606_1.md
+++ b/tests/expected/606_1.md
@@ -1,5 +1,4 @@
-*Part 1/5*
-**This Week in Rust 606** — 2025\-07\-02
+🦀 **This Week in Rust 606** — 2025\-07\-02
 
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**

--- a/tests/expected/606_3.md
+++ b/tests/expected/606_3.md
@@ -1,4 +1,5 @@
 *Part 3/5*
+
 📰 **UPDATES FROM THE RUST PROJECT** 📰
 429 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-24..2025-07-01)
 

--- a/tests/expected/606_4.md
+++ b/tests/expected/606_4.md
@@ -1,4 +1,5 @@
 *Part 4/5*
+
 • [parse new const trait syntax](https://github.com/rust-lang/rust-analyzer/pull/20105)
 • [remove last use of rustc\_pattern\_analysis::Captures](https://github.com/rust-lang/rust-analyzer/pull/20124)
 • [remove unnecessary parens in closure](https://github.com/rust-lang/rust-analyzer/pull/20122)

--- a/tests/expected/607_1.md
+++ b/tests/expected/607_1.md
@@ -1,5 +1,4 @@
-*Part 1/5*
-**This Week in Rust 607** — 2025\-07\-05
+🦀 **This Week in Rust 607** — 2025\-07\-05
 
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**

--- a/tests/expected/607_3.md
+++ b/tests/expected/607_3.md
@@ -1,4 +1,5 @@
 *Part 3/5*
+
 📰 **UPDATES FROM THE RUST PROJECT** 📰
 429 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-24..2025-07-01)
 

--- a/tests/expected/607_4.md
+++ b/tests/expected/607_4.md
@@ -1,4 +1,5 @@
 *Part 4/5*
+
 • [parse new const trait syntax](https://github.com/rust-lang/rust-analyzer/pull/20105)
 • [remove last use of rustc\_pattern\_analysis::Captures](https://github.com/rust-lang/rust-analyzer/pull/20124)
 • [remove unnecessary parens in closure](https://github.com/rust-lang/rust-analyzer/pull/20122)

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -1,5 +1,4 @@
-*Part 1/1*
-**This Week in Rust 607** — 2025\-07\-05
+🦀 **This Week in Rust 607** — 2025\-07\-05
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -1,5 +1,4 @@
-*Part 1/1*
-**Complex Example** — \#999 — 2025\-07\-10
+🦀 **Complex Example** — \#999 — 2025\-07\-10
 
 📰 **NESTED LIST** 📰
 • Item 1

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -1,5 +1,4 @@
-*Part 1/6*
-**This Week in Rust 605** — 2025\-06\-25
+🦀 **This Week in Rust 605** — 2025\-06\-25
 
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**

--- a/tests/expected/expected3.md
+++ b/tests/expected/expected3.md
@@ -1,4 +1,5 @@
 *Part 3/6*
+
 📰 **UPDATES FROM THE RUST PROJECT** 📰
 448 pull requests were [merged in the last week](https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2025-06-17..2025-06-24)
 

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -1,4 +1,5 @@
 *Part 4/6*
+
 • [rust\-analyzer: add fn parent\(self, db\) → GenericDef to hir::TypeParam](https://github.com/rust-lang/rust-analyzer/pull/20046)
 • [rust\-analyzer: cleanup folding\_ranges and support more things](https://github.com/rust-lang/rust-analyzer/pull/20080)
 • [rust\-analyzer: do not default to 'static for trait object lifetimes](https://github.com/rust-lang/rust-analyzer/pull/20036)

--- a/tests/expected/expected5.md
+++ b/tests/expected/expected5.md
@@ -1,4 +1,5 @@
 *Part 5/6*
+
 • [Rust RFCs](https://github.com/rust-lang/rfcs/labels/final-comment-period)
 • [RFC: \-\-crate\-attr](https://github.com/rust-lang/rfcs/pull/3791)
 No Items entered Final Comment Period this week for [Cargo](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -115,3 +115,11 @@ fn boundary_escape_preserved() {
         common::assert_valid_markdown(&p);
     }
 }
+
+#[test]
+fn single_section_has_expected_prefix() {
+    let input = "Title: Test\nNumber: 1\nDate: 2025-01-01\n\n## News\n- item\n";
+    let posts = generator::generate_posts(input.to_string()).unwrap();
+    assert_eq!(posts.len(), 1);
+    assert!(!posts[0].starts_with("*Part"));
+}


### PR DESCRIPTION
## Summary
- add crab emoji to issue title
- skip `*Part X/Y*` prefix for the first post
- update documentation and tests for new prefix rules

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6869e47c65e483328126a43864db8e0f