### PR TITLE
Add CFP regression test

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -33,17 +33,15 @@ fn simplify_cfp_section(section: &mut Section) {
     let mut cleaned = Vec::new();
     let mut in_projects = false;
     let mut has_task = false;
-    let mut events_index = None;
 
     for line in section.lines.iter() {
-        if line.starts_with("**CFP - Projects**") {
+        if line.starts_with("**CFP \\- Projects**") {
             in_projects = true;
             cleaned.push(line.clone());
             continue;
         }
-        if line.starts_with("**CFP - Events**") {
+        if line.starts_with("**CFP \\- Events**") {
             in_projects = false;
-            events_index = Some(cleaned.len());
             cleaned.push(line.clone());
             continue;
         }
@@ -60,7 +58,8 @@ fn simplify_cfp_section(section: &mut Section) {
             if line.trim() == "No Calls for participation were submitted this week." {
                 continue;
             }
-            if line.trim_start().starts_with('•') {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with('•') || trimmed.starts_with('*') {
                 has_task = true;
             }
             cleaned.push(line.clone());
@@ -74,8 +73,7 @@ fn simplify_cfp_section(section: &mut Section) {
             "На этой неделе новых задач нет\\. [Инструкции]({})",
             escape_markdown_url(CFP_GUIDELINES)
         );
-        let insert_at = events_index.unwrap_or(cleaned.len());
-        cleaned.insert(insert_at, msg);
+        cleaned.push(msg);
     }
 
     section.lines = cleaned;

--- a/tests/cfp_regression.rs
+++ b/tests/cfp_regression.rs
@@ -35,6 +35,34 @@ Are you a new or experienced speaker looking for a place to share something cool
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X (formerly Twitter)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)!
 "#;
 
+const CFP_EMPTY_SNIPPET: &str = r#"## Call for Participation; projects and speakers
+
+### CFP - Projects
+
+Always wanted to contribute to open-source projects but did not know where to start?
+Every week we highlight some tasks from the Rust community for you to pick and get started!
+
+Some of these tasks may also have mentors available, visit the task page for more information.
+
+<!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
+<!-- * [ - ]() -->
+<!-- or if none - *No Calls for participation were submitted this week.* -->
+*No Calls for participation were submitted this week.*
+
+If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines] or through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X (formerly Twitter)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)!
+
+[guidelines]:https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines
+
+### CFP - Events
+
+Are you a new or experienced speaker looking for a place to share something cool? This section highlights events that are being planned and are accepting submissions to join their event as a speaker.
+
+<!-- CFPs go here, use this format: * [**event name**](URL to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
+<!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
+*No Calls for papers or presentations were submitted this week.*
+
+If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X (formerly Twitter)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)!"#;
+
 #[test]
 fn cfp_section_generates_valid_markdown() {
     let input = format!("Title: Test\nNumber: 1\nDate: 2025-06-25\n\n{CFP_SNIPPET}");
@@ -42,5 +70,27 @@ fn cfp_section_generates_valid_markdown() {
     assert!(!posts.is_empty());
     for post in &posts {
         common::assert_valid_markdown(post);
+    }
+}
+
+#[test]
+fn cfp_without_tasks_inserts_message() {
+    let input = format!("Title: Test\nNumber: 1\nDate: 2025-07-05\n\n{CFP_EMPTY_SNIPPET}");
+    let posts = generate_posts(input).unwrap();
+    let combined = posts.join("\n");
+    assert!(combined.contains("На этой неделе новых задач нет"));
+    for post in posts {
+        common::assert_valid_markdown(&post);
+    }
+}
+
+#[test]
+fn cfp_with_tasks_does_not_insert_message() {
+    let input = format!("Title: Test\nNumber: 1\nDate: 2025-06-25\n\n{CFP_SNIPPET}");
+    let posts = generate_posts(input).unwrap();
+    let combined = posts.join("\n");
+    assert!(!combined.contains("На этой неделе новых задач нет"));
+    for post in posts {
+        common::assert_valid_markdown(&post);
     }
 }

--- a/tests/expected/expected2.md
+++ b/tests/expected/expected2.md
@@ -19,4 +19,3 @@ If you are a feature implementer and would like your RFC to appear on the above 
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
-На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines)


### PR DESCRIPTION
## Summary
- add regression checks for Call for Participation section
- handle escaped headings and insert no-task message only when needed
- update expected output for issue parsing

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869e21f0a108332b9e661a8e9c1d380