### PR TITLE
Добавить тест на упоминания GitHub

### DIFF
--- a/tests/github_mentions.rs
+++ b/tests/github_mentions.rs
@@ -1,0 +1,17 @@
+use twir_deploy_notify::parser;
+
+mod common;
+use parser::parse_sections;
+
+#[test]
+fn github_mentions_are_linked() {
+    let input = "## Section\n- Thanks to @user for the fix";
+    let sections = parse_sections(input);
+    assert_eq!(sections.len(), 1);
+    assert_eq!(sections[0].title, "Section");
+    assert_eq!(
+        sections[0].lines,
+        vec!["• Thanks to [user](https://github.com/user) for the fix"]
+    );
+    common::assert_valid_markdown(&sections[0].lines[0]);
+}


### PR DESCRIPTION
## Summary
- add `github_mentions.rs` ensuring `@user` becomes `[user](https://github.com/user)`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869ea70506c8332958864a5d0b0573e