### PR TITLE
Update restart instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,10 @@
   check whether `origin/main` contains new commits. Rebase your branch onto the
   latest `origin/main` if needed so all development starts from the most recent
   commit.
-- If the task includes the word "рестарт", start by updating `main` to the
-  freshest commit before continuing.
+- If the task includes the word "рестарт" or `Restart`, create a **task stub**
+  from the most recent `origin/main` commit. The stub repeats the current task's
+  requirements and launches a new merge request, leaving the previous branch
+  untouched. Prompt the user before continuing.
 - Read all Markdown (`*.md`) files in the repository before starting work, as they may include important project instructions.
 - Follow the guidelines in `PARSING.md`, especially the requirement to rely on crates for Markdown processing instead of custom parsing code.
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ If these variables are absent, the Telegram tests are skipped.
 
 ## Restart command
 
-To restart a task, use the `Restart` command. The agent will duplicate the
-original task description and create a new task based on the latest commit. A
-prompt appears asking whether to launch the task in a clean environment. See
-[RESTART.md](RESTART.md) for details.
+To restart a task, use the `Restart` command. The agent duplicates the original
+task description and prepares a **task stub** that starts from the freshest
+commit on `main`. A prompt asks whether to launch the stub as a new merge
+request, avoiding stale branches. See [RESTART.md](RESTART.md) for details.
 
 ## Commit message template
 

--- a/RESTART.md
+++ b/RESTART.md
@@ -1,9 +1,9 @@
 # Restart Command
 
-The repository uses an AI agent to generate merge requests. When the `Restart` command is issued, the agent copies the description of the current task and creates a new one that starts from the latest commit. The agent then prints:
+The repository uses an AI agent to generate merge requests. When the `Restart` command is issued, the agent copies the description of the current task and prepares a new **task stub** based on the freshest `main` commit. The agent then prints:
 
 ```
-Task restarted. Launch it on a clean commit? (Yes/No)
+Task restarted as a stub from the latest commit. Launch it? (Yes/No)
 ```
 
 Confirming will run the workflow manually on the fresh commit, avoiding merge conflicts.


### PR DESCRIPTION
## Summary
- clarify restart behaviour as task stub in AGENTS.md
- describe stub workflow in RESTART.md and README

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869ee474c888332856bb5c1f337a996