### PR TITLE
Add build-time post generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,16 @@ mockito = "1"
 proptest = "1"
 once_cell = "1"
 
+[build-dependencies]
+regex = "1"
+pulldown-cmark = "0.9"
+teloxide = { version = "0.12", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+phf = { version = "0.11", features = ["macros"] }
+log = "0.4"
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+
 [features]
 integration = []
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Scheduled runs first send the posts to the development chat using the
 `verify-posts` binary. After the messages are confirmed to appear in the
 channel, the same release is posted to the main chat.
 
+Setting the `TWIR_MARKDOWN` environment variable before building will
+parse the referenced file at compile time and embed the generated posts
+in the crate. The resulting array is available as `twir_deploy_notify::posts::POSTS`.
+
 ## Development
 
 Continuous integration runs `cargo machete` to verify that `Cargo.toml` lists only used dependencies. Run this command locally before opening a pull request.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,40 @@
+#![allow(dead_code)]
+
+use std::env;
+use std::fs;
+use std::path::Path;
+
+#[path = "src/parser.rs"]
+mod parser;
+#[path = "src/validator.rs"]
+mod validator;
+#[path = "src/generator.rs"]
+mod generator;
+
+fn main() {
+    let markdown = env::var("TWIR_MARKDOWN").ok();
+    let posts = if let Some(path) = markdown.as_deref() {
+        println!("cargo:rerun-if-changed={path}");
+        let input = fs::read_to_string(path).expect("failed to read markdown");
+        match generator::generate_posts(input) {
+            Ok(p) => p,
+            Err(e) => panic!("failed to generate posts: {e}"),
+        }
+    } else {
+        println!("cargo:warning=TWIR_MARKDOWN not set, generating empty posts");
+        Vec::new()
+    };
+
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let dest = Path::new(&out_dir).join("generated_posts.rs");
+    let mut code = String::from("// Auto-generated file.\n");
+    code.push_str("pub const POSTS: &[&str] = &[\n");
+    for p in &posts {
+        code.push_str("    r#\"");
+        code.push_str(p);
+        code.push_str("\"#,\n");
+    }
+    code.push_str("];\n");
+    fs::write(&dest, code).expect("failed to write posts file");
+    println!("cargo:rerun-if-env-changed=TWIR_MARKDOWN");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
 pub mod generator;
 pub mod parser;
+pub mod posts;
 pub mod validator;

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -1,0 +1,2 @@
+// Auto-generated posts constant included from build script.
+include!(concat!(env!("OUT_DIR"), "/generated_posts.rs"));


### PR DESCRIPTION
## Summary
- create build script to generate posts from Markdown at compile time
- expose generated posts through new `posts` module
- document `TWIR_MARKDOWN` environment variable

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869eae4393c833295d1162f76440269