### PR TITLE
Update title formatting and post prefix

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,8 @@ This tool processes weekly "This Week in Rust" Markdown files and prepares messa
 
 ## Message Generation
 - Each section becomes a separate Telegram post capped at 4000 characters.
-- Long messages are split by `split_posts`, which scans for escaped characters when breaking lines so that Telegram accepts every chunk. Each post is prefixed with `*Part X/Y*`, where `X` and `Y` are plain digits.
+- Long messages are split by `split_posts`, which scans for escaped characters when breaking lines so that Telegram accepts every chunk. Every post after the first is prefixed with `*Part X/Y*`, where `X` and `Y` are plain digits.
+- The issue title in the first post is surrounded by crab emojis.
 - The optional `--plain` flag removes Markdown formatting for channels that require plain text.
 
 ## Dependencies

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -445,7 +445,7 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
 
     let mut header = String::new();
     if let Some(ref t) = title {
-        header.push_str(&format!("**{}**", escape_markdown(t)));
+        header.push_str(&format!("🦀 **{}** 🦀", escape_markdown(t)));
     }
     if let Some(ref n) = number {
         let already_in_title = title.as_ref().map(|t| t.contains(n)).unwrap_or(false);
@@ -502,12 +502,16 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
         if !post.ends_with('\n') {
             post.push('\n');
         }
-        let formatted = format!(
-            "*Part {}/{}*\n\n{}",
-            i + 1,
-            total,
-            post.trim_start_matches('\n')
-        );
+        let formatted = if i == 0 {
+            post.trim_start_matches('\n').to_string()
+        } else {
+            format!(
+                "*Part {}/{}*\n\n{}",
+                i + 1,
+                total,
+                post.trim_start_matches('\n')
+            )
+        };
         validate_telegram_markdown(&formatted)
             .map_err(|e| ValidationError(format!("Generated post {} invalid: {e}", i + 1)))?;
         result.push(formatted);
@@ -713,7 +717,8 @@ mod tests {
         let first = dir.join("output_1.md");
         assert!(first.exists());
         let content = fs::read_to_string(first).unwrap();
-        assert!(content.contains("*Part 1/1*"));
+        assert!(!content.starts_with("*Part"));
+        assert!(content.starts_with("🦀 **Test** 🦀"));
         assert!(content.contains("📰 **NEWS** 📰"));
         assert!(content.contains("[Link](https://example.com)"));
         let _ = fs::remove_dir_all(&dir);
@@ -721,9 +726,9 @@ mod tests {
 
     #[test]
     fn plain_conversion() {
-        let text = "*Part 1/1*\n**News**\n• [Link](https://example.com)";
+        let text = "*Part 2/3*\n**News**\n• [Link](https://example.com)";
         let plain = markdown_to_plain(text);
-        assert_eq!(plain, "Part 1/1\nNews\n- Link (https://example.com)");
+        assert_eq!(plain, "Part 2/3\nNews\n- Link (https://example.com)");
     }
 
     #[test]

--- a/tests/expected/606_1.md
+++ b/tests/expected/606_1.md
@@ -1,6 +1,4 @@
-*Part 1/5*
-
-**This Week in Rust 606** — 2025\-07\-02
+🦀 **This Week in Rust 606** 🦀 — 2025\-07\-02
 
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**

--- a/tests/expected/607_1.md
+++ b/tests/expected/607_1.md
@@ -1,6 +1,4 @@
-*Part 1/5*
-
-**This Week in Rust 607** — 2025\-07\-05
+🦀 **This Week in Rust 607** 🦀 — 2025\-07\-05
 
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -1,6 +1,4 @@
-*Part 1/1*
-
-**This Week in Rust 607** — 2025\-07\-05
+🦀 **This Week in Rust 607** 🦀 — 2025\-07\-05
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
 **CFP \- Projects**

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -1,6 +1,4 @@
-*Part 1/1*
-
-**Complex Example** — \#999 — 2025\-07\-10
+🦀 **Complex Example** 🦀 — \#999 — 2025\-07\-10
 
 📰 **NESTED LIST** 📰
 • Item 1

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -1,6 +1,4 @@
-*Part 1/6*
-
-**This Week in Rust 605** — 2025\-06\-25
+🦀 **This Week in Rust 605** 🦀 — 2025\-06\-25
 
 📰 **UPDATES FROM RUST COMMUNITY** 📰
 **Official**

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -121,5 +121,5 @@ fn single_section_has_expected_prefix() {
     let input = "Title: Test\nNumber: 1\nDate: 2025-01-01\n\n## News\n- item\n";
     let posts = generator::generate_posts(input.to_string()).unwrap();
     assert_eq!(posts.len(), 1);
-    assert!(posts[0].starts_with("*Part 1/1*\n\n"));
+    assert!(!posts[0].starts_with("*Part"));
 }


### PR DESCRIPTION
## Summary
- add crab emoji to issue title
- omit Part prefix for the first post
- adjust tests and expected outputs
- document new prefix behaviour

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6869ef06bd2883329d8914bced29fa43