### PR TITLE
Add retro workflow

### DIFF
--- a/.github/workflows/retro.yml
+++ b/.github/workflows/retro.yml
@@ -1,0 +1,73 @@
+name: Retro TWIR Processing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  retro:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout TWIR
+        uses: actions/checkout@v4
+        with:
+          repository: rust-lang/this-week-in-rust
+          path: twir
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: 1.88.0
+
+      - name: Determine last 10 posts
+        id: list
+        run: |
+          files=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n 10 | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
+      - name: Build project
+        run: cargo build --quiet
+
+      - name: Compile validator helper
+        run: |
+          cat <<'RS' > validate.rs
+          extern crate twir_deploy_notify;
+          use std::{env, fs};
+          use twir_deploy_notify::validator::validate_telegram_markdown;
+          fn main() {
+              for file in env::args().skip(1) {
+                  let text = fs::read_to_string(&file).expect("read file");
+                  validate_telegram_markdown(&text).expect("invalid markdown");
+              }
+          }
+          RS
+          rustc validate.rs -L target/debug -L target/debug/deps \
+            --extern twir_deploy_notify=target/debug/libtwir_deploy_notify.rlib \
+            -o validate
+
+      - name: Process posts
+        run: |
+          set -e
+          mkdir -p artifacts
+          for path in ${{ steps.list.outputs.files }}; do
+            echo "Processing $path"
+            rm -f output_*.md
+            output=$(cargo run --quiet --bin twir-deploy-notify -- "$path")
+            messages=$(echo "$output" | grep -c '^Generated output_')
+            files=$(ls output_*.md | wc -l)
+            if [ "$messages" -ne "$files" ]; then
+              echo "Mismatch: stdout $messages vs files $files"
+              exit 1
+            fi
+            ./validate output_*.md
+            mv output_*.md artifacts/
+          done
+
+      - name: Upload generated posts
+        uses: actions/upload-artifact@v4
+        with:
+          name: retro-posts
+          path: artifacts
+          if-no-files-found: error

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -532,19 +532,12 @@ pub fn write_posts(posts: &[String], dir: &Path) -> std::io::Result<()> {
 }
 
 #[derive(Deserialize)]
-struct TelegramResponse<T> {
+struct TelegramResponse {
     ok: bool,
     #[serde(default)]
     error_code: Option<i32>,
     #[serde(default)]
     description: Option<String>,
-    result: Option<T>,
-}
-
-#[derive(Deserialize)]
-/// Subset of fields returned by `sendMessage`.
-struct SendMessageResult {
-    message_id: i64,
 }
 
 /// Send prepared posts to a Telegram chat via the HTTP API.
@@ -598,30 +591,38 @@ pub fn send_to_telegram(
         let status = resp.status();
         let body = resp.text()?;
         debug!("Telegram response {status}: {body}");
-        let data: TelegramResponse<SendMessageResult> = serde_json::from_str(&body)
+        let raw: serde_json::Value = serde_json::from_str(&body)
             .map_err(|e| format!("Failed to parse Telegram response: {e}: {body}"))?;
-        if !data.ok {
-            error!(
-                "Telegram error for post {} {}: {}",
-                i + 1,
-                data.error_code.unwrap_or_default(),
-                data.description.as_deref().unwrap_or("unknown")
-            );
-            return Err(format!(
-                "Telegram API error in post {} {}: {}",
-                i + 1,
-                data.error_code.unwrap_or_default(),
-                data.description.unwrap_or_default()
-            )
-            .into());
+        let ok = raw.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+        if !ok {
+            let code = raw
+                .get("error_code")
+                .and_then(|v| v.as_i64())
+                .unwrap_or_default();
+            let desc = raw
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            error!("Telegram error for post {} {}: {}", i + 1, code, desc);
+            return Err(format!("Telegram API error in post {} {}: {}", i + 1, code, desc).into());
         }
-        if let Some(result) = data.result {
-            if pin_first && i == 0 {
-                first_id = Some(result.message_id);
+        if pin_first {
+            match raw
+                .get("result")
+                .and_then(|v| v.get("message_id"))
+                .and_then(|v| v.as_i64())
+            {
+                Some(id) => {
+                    if i == 0 {
+                        first_id = Some(id);
+                    }
+                    last_id = Some(id);
+                }
+                None if i == 0 => {
+                    return Err("Telegram response missing message_id".into());
+                }
+                None => {}
             }
-            last_id = Some(result.message_id);
-        } else if pin_first && i == 0 {
-            return Err("Telegram response missing message_id".into());
         }
         thread::sleep(Duration::from_millis(TELEGRAM_DELAY_MS));
     }
@@ -638,8 +639,7 @@ pub fn send_to_telegram(
         let status = resp.status();
         let body = resp.text()?;
         debug!("Telegram pin response {status}: {body}");
-        use serde::de::IgnoredAny;
-        let pin_data: TelegramResponse<IgnoredAny> = serde_json::from_str(&body)
+        let pin_data: TelegramResponse = serde_json::from_str(&body)
             .map_err(|e| format!("Failed to parse Telegram pin response: {e}: {body}"))?;
         if !pin_data.ok {
             error!(
@@ -673,7 +673,7 @@ pub fn send_to_telegram(
         let status = resp.status();
         let body = resp.text()?;
         debug!("Telegram delete response {status}: {body}");
-        let delete_data: TelegramResponse<IgnoredAny> = serde_json::from_str(&body)
+        let delete_data: TelegramResponse = serde_json::from_str(&body)
             .map_err(|e| format!("Failed to parse Telegram delete response: {e}: {body}"))?;
         if !delete_data.ok {
             warn!(


### PR DESCRIPTION
## Summary
- create `retro.yml` workflow for processing old TWIR posts
- loosen response parsing in `send_to_telegram` to handle minimal `result`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869f13ecf548332be127bb247712845