### PR TITLE
Remove redundant license field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "twir-deploy-notify"
 version = "0.1.0"
 edition = "2024"
 license = "LicenseRef-QQRM-LAPOCHKA"
-license-file = "LICENSE_QQRM_LAPOCHKA"
 
 [dependencies]
 regex = "1"


### PR DESCRIPTION
## Summary
- update Cargo.toml to keep only the `license` field

## Testing
- `cargo fmt --all`
- `TWIR_MARKDOWN=dummy.md cargo check --all-targets --all-features`
- `TWIR_MARKDOWN=dummy.md cargo clippy --all-targets --all-features -- -D warnings`
- `TWIR_MARKDOWN=dummy.md cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869f7b44a9c8332844e5901756d9478