### PR TITLE
Create reusable delivery workflow

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -1,0 +1,104 @@
+name: Common TWIR delivery
+
+on:
+  workflow_call:
+    inputs:
+      send_main:
+        required: true
+        type: boolean
+      run_integration:
+        required: true
+        type: boolean
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Download last_sent artifact from previous successful run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prev=$(gh run list -w "${{ github.workflow }}" --branch main --status success -L 1 --json databaseId -q '.[0].databaseId' || echo "")
+          if [ -n "$prev" ]; then
+            gh run download "$prev" -n last-sent --dir . || true
+          fi
+
+      - name: Checkout TWIR
+        uses: actions/checkout@v4
+        with:
+          repository: rust-lang/this-week-in-rust
+          path: twir
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.88.0
+          profile: minimal
+
+      - name: Determine latest post
+        id: prepare
+        run: |
+          latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n1)
+          echo "latest_post=$latest_post" >> "$GITHUB_OUTPUT"
+          last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
+          if [ "$GITHUB_EVENT_NAME" != "schedule" ] || [ "$latest_post" != "$last_sent" ]; then
+            echo "send=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "send=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Send to dev chat
+        if: steps.prepare.outputs.send == 'true'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.DEV_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+          TELEGRAM_PIN_FIRST: '1'
+        run: |
+          rm -f output_*.md
+          cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
+          echo "${{ steps.prepare.outputs.latest_post }}" > last_sent.txt
+
+      - name: Verify dev delivery
+        if: steps.prepare.outputs.send == 'true' && github.event_name == 'schedule'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.DEV_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+        run: |
+          cargo run --quiet --bin verify-posts -- "${{ steps.prepare.outputs.latest_post }}"
+
+      - name: Run integration tests
+        if: inputs.run_integration == true
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.DEV_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+        run: cargo test --quiet --all-targets --features integration -- --test-threads=1
+
+      - name: Send to main chat
+        if: steps.prepare.outputs.send == 'true' && inputs.send_main == true && github.event_name == 'schedule'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_PIN_FIRST: '1'
+        run: |
+          cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
+
+      - name: Upload generated posts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: telegram-posts
+          path: output_*.md
+          if-no-files-found: ignore
+
+      - name: Upload last_sent artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: last-sent
+          path: last_sent.txt
+          if-no-files-found: ignore

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,20 @@
+name: Dev TWIR summary
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  notify:
+    uses: ./.github/workflows/common-delivery.yml
+    with:
+      send_main: false
+      run_integration: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release TWIR summary
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  notify:
+    uses: ./.github/workflows/common-delivery.yml
+    with:
+      send_main: true
+      run_integration: false

--- a/README.md
+++ b/README.md
@@ -57,11 +57,10 @@ Restricted environments such as the provided container may not support Docker, s
 
 The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.
 
-The Telegram API response is checked with `jq`, and the workflow fails if the server does not return `{ "ok": true }`.
-
-Scheduled runs first send the posts to the development chat using the
-`verify-posts` binary. After the messages are confirmed to appear in the
-channel, the same release is posted to the main chat.
+Responses from Telegram are verified with the `verify-posts` binary.
+Scheduled runs send the posts to the development chat through the `dev.yml` workflow.
+After the messages are confirmed to appear in the channel, the manual `release.yml` workflow
+posts the same release to the main chat.
 
 Setting the `TWIR_MARKDOWN` environment variable before building will
 parse the referenced file at compile time and embed the generated posts


### PR DESCRIPTION
## Summary
- add a reusable workflow `common-delivery.yml`
- call it from new `dev.yml` and `release.yml`
- note workflow names in README

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869f93aa47083328c0f2ee31074c734