### PR TITLE
Добавить отдельный workflow для релиза

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release TWIR summary
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Download last_sent artifact from previous successful run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prev=$(gh run list -w "${{ github.workflow }}" --branch main --status success -L 1 --json databaseId -q '.[0].databaseId' || echo "")
+          if [ -n "$prev" ]; then
+            gh run download "$prev" -n last-sent --dir . || true
+          fi
+
+      - name: Checkout TWIR
+        uses: actions/checkout@v4
+        with:
+          repository: rust-lang/this-week-in-rust
+          path: twir
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.88.0
+          profile: minimal
+
+      - name: Determine latest post
+        id: prepare
+        run: |
+          latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n 1)
+          echo "latest_post=$latest_post" >> "$GITHUB_OUTPUT"
+          last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
+          if [ "$GITHUB_EVENT_NAME" != "schedule" ] || [ "$latest_post" != "$last_sent" ]; then
+            echo "send=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "send=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Send to dev chat
+        if: steps.prepare.outputs.send == 'true'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.DEV_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+          TELEGRAM_PIN_FIRST: '1'
+        run: |
+          rm -f output_*.md
+          cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
+          echo "${{ steps.prepare.outputs.latest_post }}" > last_sent.txt
+
+      - name: Verify dev delivery
+        if: steps.prepare.outputs.send == 'true'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.DEV_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
+        run: |
+          cargo run --quiet --bin verify-posts -- "${{ steps.prepare.outputs.latest_post }}"
+
+      - name: Send to main chat
+        if: steps.prepare.outputs.send == 'true'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_PIN_FIRST: '1'
+        run: |
+          cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
+
+      - name: Upload generated posts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: telegram-posts
+          path: output_*.md
+          if-no-files-found: ignore
+
+      - name: Upload last_sent artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: last-sent
+          path: last_sent.txt
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Scheduled runs first send the posts to the development chat using the
 `verify-posts` binary. After the messages are confirmed to appear in the
 channel, the same release is posted to the main chat.
 
+Two manual workflows exist in GitHub Actions. **Send TWIR summary** publishes
+the post only to the development channel, while **Release TWIR summary** sends
+the verified messages to the main chat.
+
 Setting the `TWIR_MARKDOWN` environment variable before building will
 parse the referenced file at compile time and embed the generated posts
 in the crate. The resulting array is available as `twir_deploy_notify::posts::POSTS`.


### PR DESCRIPTION
## Summary
- revert release input from main workflow
- create a new `release.yml` workflow for publishing to the main channel
- document the two manual workflows in README

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869f51533908332970c6d4d11753479