### PR TITLE
docs: clarify default commit trailer

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -3,4 +3,4 @@
 # Leave a blank line after the summary and wrap lines at 72 characters.
 # Describe the motivation and changes in the body if necessary.
 # Append the following trailer for AI-generated contributions.
-Co-authored-by: Codex Agent <email@example.com>
+Co-authored-by: CODEX from ChatGPT <codex@example.com>

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ the template once using:
 git config commit.template .gitmessage
 ```
 
+The template includes the following default trailer:
+
+```text
+Co-authored-by: CODEX from ChatGPT <codex@example.com>
+```
+
 Adjust the agent name or email by editing `.gitmessage` directly or by setting
 `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` before committing.
 


### PR DESCRIPTION
## Summary
- clarify README instructions on commit template
- update `.gitmessage` to specify the default co-author line

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869fab470548332b9d6d71bcf08f67e