### PR TITLE
Remove unused act mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ Telegram:
 - `TELEGRAM_CHAT_ID` – the identifier of the chat or channel.
 - `TELEGRAM_PIN_FIRST` – set to `1` or `true` to pin the first sent message.
   The service message about the pin will be deleted automatically.
-
-Running the workflow with [`act`](https://github.com/nektos/act) is possible, but it requires Docker.
-Restricted environments such as the provided container may not support Docker, so executing the above
-`cargo` commands manually remains the recommended approach.
-
 The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.
 
 Responses from Telegram are verified with the `verify-posts` binary.


### PR DESCRIPTION
## Summary
- drop leftover `act` reference from README

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6869f8f262b88332ad98669dd70e9bdf