### PR TITLE
Add Git history drop workflow

### DIFF
--- a/.github/workflows/drop-history.yml
+++ b/.github/workflows/drop-history.yml
@@ -1,0 +1,29 @@
+name: Drop Git history
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  drop-history:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create orphan branch with final state
+        run: |
+          git checkout --orphan new-main
+          git add -A
+          git commit -m "Preserve final project state"
+
+      - name: Push new branch
+        run: git push origin HEAD:new-main --force
+
+      - name: Replace main with new branch
+        run: |
+          git push origin --delete main || true
+          git push origin new-main:main --force

--- a/.gitmessage
+++ b/.gitmessage
@@ -3,4 +3,4 @@
 # Leave a blank line after the summary and wrap lines at 72 characters.
 # Describe the motivation and changes in the body if necessary.
 # Append the following trailer for AI-generated contributions.
-Co-authored-by: Codex Agent <email@example.com>
+Co-authored-by: CODEX from ChatGPT <codex@example.com>

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ the template once using:
 git config commit.template .gitmessage
 ```
 
+The template includes the following default trailer:
+
+```text
+Co-authored-by: CODEX from ChatGPT <codex@example.com>
+```
+
 Adjust the agent name or email by editing `.gitmessage` directly or by setting
 `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` before committing.
 


### PR DESCRIPTION
## Summary
- add a workflow to reset `main` to a single commit

## Testing
- `cargo check --all-targets --all-features`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6869fc4364c48332aff04c8ce1194180