### PR TITLE
Add performance triage emoji

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -24,6 +24,7 @@ pub static SUBHEADING_EMOJIS: phf::Map<&'static str, &'static str> = phf_map! {
     "rustdoc" => "📖",
     "clippy" => "🔧",
     "rust-analyzer" => "🤖",
+    "rust compiler performance triage" => "📊",
     "tracking issues & prs" => "📌",
 };
 

--- a/tests/expected/606_4.md
+++ b/tests/expected/606_4.md
@@ -4,7 +4,8 @@
 • [remove last use of rustc\_pattern\_analysis::Captures](https://github.com/rust-lang/rust-analyzer/pull/20124)
 • [remove unnecessary parens in closure](https://github.com/rust-lang/rust-analyzer/pull/20122)
 • [salsa idiomize VariantFields query](https://github.com/rust-lang/rust-analyzer/pull/20106)
-**Rust Compiler Performance Triage**
+
+**Rust Compiler Performance Triage:** 📊
 Lots of changes this week with results dominated by the 1\-5% improvements from [\#142941](https://github.com/rust-lang/rust/pull/142941) across lots of primary benchmarks in the suite\.
 Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total

--- a/tests/expected/607_4.md
+++ b/tests/expected/607_4.md
@@ -4,7 +4,8 @@
 • [remove last use of rustc\_pattern\_analysis::Captures](https://github.com/rust-lang/rust-analyzer/pull/20124)
 • [remove unnecessary parens in closure](https://github.com/rust-lang/rust-analyzer/pull/20122)
 • [salsa idiomize VariantFields query](https://github.com/rust-lang/rust-analyzer/pull/20106)
-**Rust Compiler Performance Triage**
+
+**Rust Compiler Performance Triage:** 📊
 Lots of changes this week with results dominated by the 1\-5% improvements from [\#142941](https://github.com/rust-lang/rust/pull/142941) across lots of primary benchmarks in the suite\.
 Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -11,7 +11,8 @@
 • [rust\-analyzer: use ROOT hygiene for args inside new format\_args\! expansion](https://github.com/rust-lang/rust-analyzer/pull/20073)
 • [rust\-analyzer: hide imported privates if private editable is disabled](https://github.com/rust-lang/rust-analyzer/pull/20025)
 • [rust\-analyzer: mimic rustc's new format\_args\! expansion](https://github.com/rust-lang/rust-analyzer/pull/20056)
-**Rust Compiler Performance Triage**
+
+**Rust Compiler Performance Triage:** 📊
 A week dominated by the landing of a large patch implementing [RFC\#3729](https://github.com/rust-lang/rfcs/pull/3729) which unfortunately introduced rather sizeable performance regressions \(avg of \~1% instruction count on 111 primary benchmarks\)\. This was deemed worth it so that the patch could land and performance could be won back in follow up PRs\.
 Triage done by [rylev](https://github.com/rylev)\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)
 Summary:


### PR DESCRIPTION
## Summary
- support "Rust Compiler Performance Triage" subheading
- update expected output fixtures

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686a03f43f908332bb3a55abeb6e5953