### PR TITLE
Add quote spacing and triage emoji tests

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -25,6 +25,7 @@ pub static SUBHEADING_EMOJIS: phf::Map<&'static str, &'static str> = phf_map! {
     "clippy" => "🔧",
     "rust-analyzer" => "🤖",
     "tracking issues & prs" => "📌",
+    "rust compiler performance triage" => "📈",
 };
 
 /// Short URL guiding contributors how to submit CFP tasks.
@@ -86,7 +87,6 @@ fn simplify_quote_section(section: &mut Section) {
     for line in &section.lines {
         if line.contains("Quote of the Week") {
             cleaned.push(format_subheading("Quote of the Week"));
-            cleaned.push(String::new());
             in_quote = true;
             continue;
         }
@@ -100,6 +100,7 @@ fn simplify_quote_section(section: &mut Section) {
             }
             if line.trim_start().starts_with('–') {
                 in_quote = false;
+                cleaned.push(String::new());
                 cleaned.push(line.trim_start().to_string());
                 continue;
             }

--- a/tests/expected/606_4.md
+++ b/tests/expected/606_4.md
@@ -4,7 +4,8 @@
 • [remove last use of rustc\_pattern\_analysis::Captures](https://github.com/rust-lang/rust-analyzer/pull/20124)
 • [remove unnecessary parens in closure](https://github.com/rust-lang/rust-analyzer/pull/20122)
 • [salsa idiomize VariantFields query](https://github.com/rust-lang/rust-analyzer/pull/20106)
-**Rust Compiler Performance Triage**
+
+**Rust Compiler Performance Triage:** 📈
 Lots of changes this week with results dominated by the 1\-5% improvements from [\#142941](https://github.com/rust-lang/rust/pull/142941) across lots of primary benchmarks in the suite\.
 Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total

--- a/tests/expected/606_5.md
+++ b/tests/expected/606_5.md
@@ -7,9 +7,9 @@
 
 **Quote of the Week:** 💬
 
-
 _I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\._
 _And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\._
+
 – [Remo Senekowitsch blogging about their Rust 4 Linux adventure](https://blog.buenzli.dev/rust-for-linux-first-contrib/)
 Despite a lamentable lack of suggestions, llogiq is reasonably pleased with his choice\.
 [Please submit quotes and vote for next week\!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)

--- a/tests/expected/607_4.md
+++ b/tests/expected/607_4.md
@@ -4,7 +4,8 @@
 • [remove last use of rustc\_pattern\_analysis::Captures](https://github.com/rust-lang/rust-analyzer/pull/20124)
 • [remove unnecessary parens in closure](https://github.com/rust-lang/rust-analyzer/pull/20122)
 • [salsa idiomize VariantFields query](https://github.com/rust-lang/rust-analyzer/pull/20106)
-**Rust Compiler Performance Triage**
+
+**Rust Compiler Performance Triage:** 📈
 Lots of changes this week with results dominated by the 1\-5% improvements from [\#142941](https://github.com/rust-lang/rust/pull/142941) across lots of primary benchmarks in the suite\.
 Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total

--- a/tests/expected/607_5.md
+++ b/tests/expected/607_5.md
@@ -7,9 +7,9 @@
 
 **Quote of the Week:** 💬
 
-
 _I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\._
 _And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\._
+
 – [Remo Senekowitsch blogging about their Rust 4 Linux adventure](https://blog.buenzli.dev/rust-for-linux-first-contrib/)
 Despite a lamentable lack of suggestions, llogiq is reasonably pleased with his choice\.
 [Please submit quotes and vote for next week\!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -11,7 +11,8 @@
 • [rust\-analyzer: use ROOT hygiene for args inside new format\_args\! expansion](https://github.com/rust-lang/rust-analyzer/pull/20073)
 • [rust\-analyzer: hide imported privates if private editable is disabled](https://github.com/rust-lang/rust-analyzer/pull/20025)
 • [rust\-analyzer: mimic rustc's new format\_args\! expansion](https://github.com/rust-lang/rust-analyzer/pull/20056)
-**Rust Compiler Performance Triage**
+
+**Rust Compiler Performance Triage:** 📈
 A week dominated by the landing of a large patch implementing [RFC\#3729](https://github.com/rust-lang/rfcs/pull/3729) which unfortunately introduced rather sizeable performance regressions \(avg of \~1% instruction count on 111 primary benchmarks\)\. This was deemed worth it so that the patch could land and performance could be won back in follow up PRs\.
 Triage done by [rylev](https://github.com/rylev)\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)
 Summary:

--- a/tests/expected/expected6.md
+++ b/tests/expected/expected6.md
@@ -7,8 +7,8 @@
 
 **Quote of the Week:** 💬
 
-
 _Our experience is that no matter how many safeguards you put on code, there’s no cure\-all that prevents bad programming\. Of course, to take the contrary argument, seat belts don’t stop all traffic fatalities, but you could just choose not to have accidents\. So we do have seat belts\. If Rust can prevent some mistakes or malicious intent, maybe it’s worth it even if it isn’t perfect\._
+
 – [Al Williams on hackaday](https://hackaday.com/2025/06/21/if-your-kernel-development-is-a-little-rusty/)
 Thanks to [Kill The Mule](https://users.rust-lang.org/t/twir-quote-of-the-week/328/1700) for the suggestion\!
 [Please submit quotes and vote for next week\!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -123,3 +123,26 @@ fn single_section_has_expected_prefix() {
     assert_eq!(posts.len(), 1);
     assert!(!posts[0].starts_with("*Part"));
 }
+
+#[test]
+fn quote_spacing_is_correct() {
+    let posts =
+        generator::generate_posts(include_str!("2025-06-25-this-week-in-rust.md").to_string())
+            .unwrap();
+    let post = posts.last().expect("missing final post");
+    let lines: Vec<_> = post.lines().collect();
+    let idx = lines
+        .iter()
+        .position(|l| l.contains("Quote of the Week"))
+        .expect("quote heading missing");
+    assert_eq!(lines[idx + 1], "");
+    assert!(!lines[idx + 2].is_empty());
+    assert_eq!(lines[idx + 3], "");
+    assert!(lines[idx + 4].starts_with('–'));
+}
+
+#[test]
+fn triage_heading_has_emoji() {
+    let out = generator::format_subheading("Rust Compiler Performance Triage");
+    assert!(out.contains('📈'));
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -550,6 +550,15 @@ fn parse_call_for_participation() {
 }
 
 #[test]
+fn triage_heading_contains_emoji() {
+    let posts =
+        generator::generate_posts(include_str!("2025-06-25-this-week-in-rust.md").to_string())
+            .unwrap();
+    let combined = posts.join("\n");
+    assert!(combined.contains("**Rust Compiler Performance Triage:** 📈"));
+}
+
+#[test]
 fn jobs_links_present() {
     let input = include_str!("2025-07-05-this-week-in-rust.md");
     let posts = generator::generate_posts(input.to_string()).unwrap();


### PR DESCRIPTION
## Summary
- enforce cleaner Quote of the Week formatting
- mark Rust Compiler Performance Triage heading with an emoji
- check quote spacing and triage emoji in unit tests
- refresh integration fixtures for new formatting

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686a03f49f2483328779e273ca959f3b