### PR TITLE
Fix quote spacing

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -86,7 +86,6 @@ fn simplify_quote_section(section: &mut Section) {
     for line in &section.lines {
         if line.contains("Quote of the Week") {
             cleaned.push(format_subheading("Quote of the Week"));
-            cleaned.push(String::new());
             in_quote = true;
             continue;
         }
@@ -101,6 +100,7 @@ fn simplify_quote_section(section: &mut Section) {
             if line.trim_start().starts_with('–') {
                 in_quote = false;
                 cleaned.push(line.trim_start().to_string());
+                cleaned.push(String::new());
                 continue;
             }
             let content = line.trim_start_matches("\\>").trim_start();

--- a/tests/expected/606_5.md
+++ b/tests/expected/606_5.md
@@ -7,10 +7,10 @@
 
 **Quote of the Week:** 💬
 
-
 _I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\._
 _And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\._
 – [Remo Senekowitsch blogging about their Rust 4 Linux adventure](https://blog.buenzli.dev/rust-for-linux-first-contrib/)
+
 Despite a lamentable lack of suggestions, llogiq is reasonably pleased with his choice\.
 [Please submit quotes and vote for next week\!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)
 This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [U007D](https://github.com/U007D), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin), [bennyvasquez](https://github.com/bennyvasquez), [bdillo](https://github.com/bdillo)

--- a/tests/expected/607_5.md
+++ b/tests/expected/607_5.md
@@ -7,10 +7,10 @@
 
 **Quote of the Week:** 💬
 
-
 _I love Rust, so I was already biased to be positive about the Rust for Linux project, even before dabbling with it myself\. I'm genuinely surprised to be even more optimistic now than before\. The coding part was much easier than I imagined, thanks to the use of reference counting in the kernel\._
 _And the promised benefits of Rust over C? They're absolutely real\. The Rust version of the driver feels way more robust than the C code, not just regarding memory safety\. It didn't have a single bug: Once it compiled, it worked\. That's not a huge deal considering it was a direct rewrite, but it counts for something\._
 – [Remo Senekowitsch blogging about their Rust 4 Linux adventure](https://blog.buenzli.dev/rust-for-linux-first-contrib/)
+
 Despite a lamentable lack of suggestions, llogiq is reasonably pleased with his choice\.
 [Please submit quotes and vote for next week\!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)
 This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [U007D](https://github.com/U007D), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin), [bennyvasquez](https://github.com/bennyvasquez), [bdillo](https://github.com/bdillo)

--- a/tests/expected/expected6.md
+++ b/tests/expected/expected6.md
@@ -7,9 +7,9 @@
 
 **Quote of the Week:** 💬
 
-
 _Our experience is that no matter how many safeguards you put on code, there’s no cure\-all that prevents bad programming\. Of course, to take the contrary argument, seat belts don’t stop all traffic fatalities, but you could just choose not to have accidents\. So we do have seat belts\. If Rust can prevent some mistakes or malicious intent, maybe it’s worth it even if it isn’t perfect\._
 – [Al Williams on hackaday](https://hackaday.com/2025/06/21/if-your-kernel-development-is-a-little-rusty/)
+
 Thanks to [Kill The Mule](https://users.rust-lang.org/t/twir-quote-of-the-week/328/1700) for the suggestion\!
 [Please submit quotes and vote for next week\!](https://users.rust-lang.org/t/twir-quote-of-the-week/328)
 This Week in Rust is edited by: [nellshamrell](https://github.com/nellshamrell), [llogiq](https://github.com/llogiq), [cdmistman](https://github.com/cdmistman), [ericseppanen](https://github.com/ericseppanen), [extrawurst](https://github.com/extrawurst), [U007D](https://github.com/U007D), [joelmarcey](https://github.com/joelmarcey), [mariannegoldin](https://github.com/mariannegoldin), [bennyvasquez](https://github.com/bennyvasquez), [bdillo](https://github.com/bdillo)

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -123,3 +123,23 @@ fn single_section_has_expected_prefix() {
     assert_eq!(posts.len(), 1);
     assert!(!posts[0].starts_with("*Part"));
 }
+
+#[test]
+fn quote_section_spacing() {
+    let posts =
+        generator::generate_posts(include_str!("2025-07-02-this-week-in-rust.md").to_string())
+            .unwrap();
+    assert!(posts.len() >= 5);
+    let lines: Vec<_> = posts[4].lines().collect();
+    let idx = lines
+        .iter()
+        .position(|l| l.contains("Quote of the Week"))
+        .unwrap();
+    assert!(lines.get(idx + 1).is_some_and(|l| l.is_empty()));
+    assert!(lines.get(idx + 2).is_some_and(|l| !l.is_empty()));
+    let author_idx = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with('–'))
+        .unwrap();
+    assert!(lines.get(author_idx + 1).is_some_and(|l| l.is_empty()));
+}


### PR DESCRIPTION
## Summary
- handle Quote of the Week spacing consistently
- update expected test outputs
- verify quote spacing in tests

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686a03e8f5008332be519419bf39ecb9