### PR TITLE
Fix final sleep in Telegram sender

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -636,7 +636,9 @@ pub fn send_to_telegram(
                 None => {}
             }
         }
-        thread::sleep(Duration::from_millis(TELEGRAM_DELAY_MS));
+        if i + 1 < posts.len() {
+            thread::sleep(Duration::from_millis(TELEGRAM_DELAY_MS));
+        }
     }
     if let Some(msg_id) = first_id {
         let pin_url = format!(


### PR DESCRIPTION
## Summary
- only sleep between Telegram posts
- ensure formatting, linting, and tests pass

## Testing
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686a666b09cc8332801b6c273d04d832