### PR TITLE
Fix TWIR checkout step order

### DIFF
--- a/.github/workflows/retro.yml
+++ b/.github/workflows/retro.yml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_PROGRESS_WHEN: never
-    steps:
-      - uses: actions/checkout@v4
+      steps:
+        - uses: actions/checkout@v4
 
-      - name: Checkout TWIR
-        uses: actions/checkout@v4
-        with:
-          repository: rust-lang/this-week-in-rust
-          path: twir
+        - uses: ./.github/actions/setup-rust
+          with:
+            toolchain: 1.88.0
 
-      - uses: ./.github/actions/setup-rust
-        with:
-          toolchain: 1.88.0
+        - name: Checkout TWIR
+          uses: actions/checkout@v4
+          with:
+            repository: rust-lang/this-week-in-rust
+            path: twir
 
       - name: Determine last 10 posts
         id: list


### PR DESCRIPTION
## Summary
- setup rust toolchain before TWIR repository checkout to keep the `twir` folder

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686a668b9c408332b954a1fddfd54505