### PR TITLE
Handle fenced code blocks correctly

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -245,7 +245,7 @@ pub fn parse_sections(text: &str) -> Vec<Section> {
                 buffer.push_str("```");
             }
             Event::Text(t) | Event::Code(t) => {
-                if in_heading {
+                if in_code_block || in_heading {
                     buffer.push_str(&t);
                 } else {
                     buffer.push_str(&escape_markdown(&t));

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -15,9 +15,9 @@ Back to first level
 
 📰 **CODE BLOCK** 📰
 ```
-fn greet\(\) \{
-    println\!\("Hello, world\!"\);
-\}
+fn greet() {
+    println!("Hello, world!");
+}
 ```
 
 📰 **TABLE EXAMPLE** 📰

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -24,3 +24,14 @@ fn bare_link_with_parentheses() {
     );
     common::assert_valid_markdown(&sections[0].lines[0]);
 }
+
+#[test]
+fn fenced_code_block_round_trip() {
+    let input = "## Section\n```\nfn main() {\n    println!(\"Hello_world\");\n}\n```";
+    let sections = parse_sections(input);
+    assert_eq!(sections.len(), 1);
+    assert_eq!(
+        sections[0].lines,
+        vec!["```\nfn main() {\n    println!(\"Hello_world\");\n}\n```"]
+    );
+}


### PR DESCRIPTION
## Summary
- stop escaping code when inside fenced blocks in parser
- allow reserved characters in validator when inside a code block
- update complex fixture output
- add regression test for fenced code blocks

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686a669593748332a594e3152d495dc2