### PR TITLE
Fix markdown URL escaping for RFC links

### DIFF
--- a/tests/expected/606_4.md
+++ b/tests/expected/606_4.md
@@ -10,7 +10,7 @@ Lots of changes this week with results dominated by the 1\-5% improvements from 
 Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025/2025-06-30.md)
-**\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**
+**[Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)**
 Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
 • No RFCs were approved this week\.
 **Final Comment Period**
@@ -30,5 +30,5 @@ Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final
 • [feat\(publish\): Stabilize multi\-package publishing](https://github.com/rust-lang/cargo/pull/15636)
 No Items entered Final Comment Period this week for [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.
 Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.
-**\[New and Updated RFCs\]\(https://github\.com/rust\-lang/rfcs/pulls\)**
+**[New and Updated RFCs](https://github.com/rust-lang/rfcs/pulls)**
 • No New or Updated RFCs were created this week\.

--- a/tests/expected/607_4.md
+++ b/tests/expected/607_4.md
@@ -10,7 +10,7 @@ Lots of changes this week with results dominated by the 1\-5% improvements from 
 Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025/2025-06-30.md)
-**\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**
+**[Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)**
 Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
 • No RFCs were approved this week\.
 **Final Comment Period**
@@ -30,5 +30,5 @@ Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final
 • [feat\(publish\): Stabilize multi\-package publishing](https://github.com/rust-lang/cargo/pull/15636)
 No Items entered Final Comment Period this week for [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.
 Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.
-**\[New and Updated RFCs\]\(https://github\.com/rust\-lang/rfcs/pulls\)**
+**[New and Updated RFCs](https://github.com/rust-lang/rfcs/pulls)**
 • No New or Updated RFCs were created this week\.

--- a/tests/expected/expected2.md
+++ b/tests/expected/expected2.md
@@ -5,9 +5,9 @@ An important step for RFC implementation is for people to experiment with the im
 If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 • No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.
 [Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list\.
-**\[RFCs\]\(https://github\.com/rust\-lang/rfcs/issues?q\=label%3Acall\-for\-testing\)**
-**\[Rust\]\(https://github\.com/rust\-lang/rust/labels/call\-for\-testing\)**
-**\[Rustup\]\(https://github\.com/rust\-lang/rustup/labels/call\-for\-testing\)**
+**[RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing)**
+**[Rust](https://github.com/rust-lang/rust/labels/call-for-testing)**
+**[Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)**
 If you are a feature implementer and would like your RFC to appear on the above list, add the new call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -24,7 +24,7 @@ Summary:
 | All ❌✅ \(primary\)              | 1\.0%   | \[\-7\.3%, 9\.1%\]    | 125   |
 2 Regressions, 4 Improvements, 10 Mixed; 7 of them in rollups 40 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/a63db4d1799853b334e4106d914fba24e49c8782/triage/2025/2025-06-24.md)
-**\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**
+**[Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)**
 Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
 • No RFCs were approved this week\.
 **Final Comment Period**

--- a/tests/expected/expected5.md
+++ b/tests/expected/expected5.md
@@ -4,5 +4,5 @@
 • [RFC: \-\-crate\-attr](https://github.com/rust-lang/rfcs/pull/3791)
 No Items entered Final Comment Period this week for [Cargo](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.
 Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.
-**\[New and Updated RFCs\]\(https://github\.com/rust\-lang/rfcs/pulls\)**
+**[New and Updated RFCs](https://github.com/rust-lang/rfcs/pulls)**
 • No New or Updated RFCs were created this week\.

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -20,7 +20,7 @@ fn bare_link_with_parentheses() {
     assert_eq!(sections[0].title, "Section");
     assert_eq!(
         sections[0].lines,
-        vec!["• [Some text](https://example.com/path(1\\))"]
+        vec!["• [Some text](https://example.com/path\\(1\\))"]
     );
     common::assert_valid_markdown(&sections[0].lines[0]);
 }


### PR DESCRIPTION
## Summary
- escape parentheses only in URLs
- correctly parse link subheadings
- update expected Markdown outputs and parser tests

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686a6bc5c7d4833285d4c54daee068c3