### PR TITLE
Fix retro workflow indentation

### DIFF
--- a/.github/workflows/retro.yml
+++ b/.github/workflows/retro.yml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_PROGRESS_WHEN: never
-      steps:
-        - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-        - uses: ./.github/actions/setup-rust
-          with:
-            toolchain: 1.88.0
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: 1.88.0
 
-        - name: Checkout TWIR
-          uses: actions/checkout@v4
-          with:
-            repository: rust-lang/this-week-in-rust
-            path: twir
+      - name: Checkout TWIR
+        uses: actions/checkout@v4
+        with:
+          repository: rust-lang/this-week-in-rust
+          path: twir
 
       - name: Determine last 10 posts
         id: list


### PR DESCRIPTION
## Summary
- fix `steps:` indentation under `jobs.retro` in GitHub Actions so that steps are executed

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686a6c5379e483329910f9428cc41108