### PR TITLE
Ensure consistent subheading formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output_*.md
 twir/
 
 last_sent.txt
+# Ignore generated outputs

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -36,12 +36,12 @@ fn simplify_cfp_section(section: &mut Section) {
     let mut has_task = false;
 
     for line in section.lines.iter() {
-        if line.starts_with("**CFP \\- Projects**") {
+        if line.trim_start().starts_with("**CFP \\- Projects**") {
             in_projects = true;
             cleaned.push(line.clone());
             continue;
         }
-        if line.starts_with("**CFP \\- Events**") {
+        if line.trim_start().starts_with("**CFP \\- Events**") {
             in_projects = false;
             cleaned.push(line.clone());
             continue;
@@ -216,7 +216,7 @@ pub fn format_subheading(title: &str) -> String {
     if let Some(emoji) = SUBHEADING_EMOJIS.get(lower.as_str()) {
         format!("\n**{}:** {}", escape_markdown(trimmed), emoji)
     } else {
-        format!("**{}**", escape_markdown(trimmed))
+        format!("\n**{}**", escape_markdown(trimmed))
     }
 }
 
@@ -825,7 +825,7 @@ mod tests {
     fn subheading_with_dash() {
         let text = "## Section\n### Foo-Bar\n- item\n";
         let secs = parse_sections(text);
-        assert_eq!(secs[0].lines[0], "**Foo\\-Bar**");
+        assert_eq!(secs[0].lines[0], "\n**Foo\\-Bar**");
         let posts = generate_posts(
             "Title: T\nNumber: 1\nDate: 2025-01-01\n\n## Section\n### Foo-Bar\n- item\n"
                 .to_string(),

--- a/tests/expected/606_1.md
+++ b/tests/expected/606_1.md
@@ -1,6 +1,7 @@
 \#606 — 2025\-07\-02
 
 📰 **UPDATES FROM RUST COMMUNITY** 📰
+
 **Official**
 • [Announcing Rust 1\.88\.0 \| Rust Blog](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)
 • [Now accepting Project Goal proposals for 2025H2](https://blog.rust-lang.org/inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions/)
@@ -35,6 +36,7 @@
 
 **Rust Walkthroughs:** 📚
 • [Alternative Blanket Implementations for a Single Rust Trait](https://www.greyblake.com/blog/alternative-blanket-implementations-for-single-rust-trait/)
+
 **Miscellaneous**
 • [Reflections on Haskell and Rust](https://academy.fpblock.com/blog/rust-haskell-reflections/)
 

--- a/tests/expected/606_2.md
+++ b/tests/expected/606_2.md
@@ -7,8 +7,10 @@ If you are a feature implementer and would like your RFC to appear in this list,
 [Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list\.
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
+
 **CFP \- Projects**
 No Calls for participation were submitted this week\.
+
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!

--- a/tests/expected/606_4.md
+++ b/tests/expected/606_4.md
@@ -10,9 +10,11 @@ Lots of changes this week with results dominated by the 1\-5% improvements from 
 Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025/2025-06-30.md)
+
 **\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**
 Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
 • No RFCs were approved this week\.
+
 **Final Comment Period**
 Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs which are reaching a decision\. Express your opinions now\.
 
@@ -30,5 +32,6 @@ Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final
 • [feat\(publish\): Stabilize multi\-package publishing](https://github.com/rust-lang/cargo/pull/15636)
 No Items entered Final Comment Period this week for [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.
 Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.
+
 **\[New and Updated RFCs\]\(https://github\.com/rust\-lang/rfcs/pulls\)**
 • No New or Updated RFCs were created this week\.

--- a/tests/expected/607_1.md
+++ b/tests/expected/607_1.md
@@ -1,6 +1,7 @@
 \#607 — 2025\-07\-05
 
 📰 **UPDATES FROM RUST COMMUNITY** 📰
+
 **Official**
 • [Announcing Rust 1\.88\.0 \| Rust Blog](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)
 • [Now accepting Project Goal proposals for 2025H2](https://blog.rust-lang.org/inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions/)
@@ -35,6 +36,7 @@
 
 **Rust Walkthroughs:** 📚
 • [Alternative Blanket Implementations for a Single Rust Trait](https://www.greyblake.com/blog/alternative-blanket-implementations-for-single-rust-trait/)
+
 **Miscellaneous**
 • [Reflections on Haskell and Rust](https://academy.fpblock.com/blog/rust-haskell-reflections/)
 

--- a/tests/expected/607_2.md
+++ b/tests/expected/607_2.md
@@ -7,8 +7,10 @@ If you are a feature implementer and would like your RFC to appear in this list,
 [Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list\.
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
+
 **CFP \- Projects**
 No Calls for participation were submitted this week\.
+
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!

--- a/tests/expected/607_4.md
+++ b/tests/expected/607_4.md
@@ -10,9 +10,11 @@ Lots of changes this week with results dominated by the 1\-5% improvements from 
 Triage done by [simulacrum](https://github.com/simulacrum)\. Revision range: [42245d34\.\.ad3b7257](https://perf.rust-lang.org/?start=42245d34d22ade32b3f276dcf74deb826841594c&end=ad3b7257615c28aaf8212a189ec032b8af75de51&absolute=false&stat=instructions%3Au)
 3 Regressions, 6 Improvements, 5 Mixed; 4 of them in rollups 39 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/master/triage/2025/2025-06-30.md)
+
 **\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**
 Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
 • No RFCs were approved this week\.
+
 **Final Comment Period**
 Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs which are reaching a decision\. Express your opinions now\.
 
@@ -30,5 +32,6 @@ Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final
 • [feat\(publish\): Stabilize multi\-package publishing](https://github.com/rust-lang/cargo/pull/15636)
 No Items entered Final Comment Period this week for [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.
 Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.
+
 **\[New and Updated RFCs\]\(https://github\.com/rust\-lang/rfcs/pulls\)**
 • No New or Updated RFCs were created this week\.

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -1,8 +1,10 @@
 \#607 — 2025\-07\-05
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
+
 **CFP \- Projects**
 No Calls for participation were submitted this week\.
+
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!

--- a/tests/expected/expected1.md
+++ b/tests/expected/expected1.md
@@ -1,6 +1,7 @@
 \#605 — 2025\-06\-25
 
 📰 **UPDATES FROM RUST COMMUNITY** 📰
+
 **Official**
 • [Announcing the Clippy feature freeze](https://blog.rust-lang.org/inside-rust/2025/06/21/announcing-the-clippy-feature-freeze/)
 

--- a/tests/expected/expected2.md
+++ b/tests/expected/expected2.md
@@ -5,17 +5,22 @@ An important step for RFC implementation is for people to experiment with the im
 If you are a feature implementer and would like your RFC to appear in this list, add a call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 • No calls for testing were issued this week by [Rust](https://github.com/rust-lang/rust/labels/call-for-testing), [Rust language RFCs](https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing), [Cargo](https://github.com/rust-lang/cargo/labels/call-for-testing) or [Rustup](https://github.com/rust-lang/rustup/labels/call-for-testing)\.
 [Let us know](https://github.com/rust-lang/this-week-in-rust/issues) if you would like your feature to be tracked as a part of this list\.
+
 **\[RFCs\]\(https://github\.com/rust\-lang/rfcs/issues?q\=label%3Acall\-for\-testing\)**
+
 **\[Rust\]\(https://github\.com/rust\-lang/rust/labels/call\-for\-testing\)**
+
 **\[Rustup\]\(https://github\.com/rust\-lang/rustup/labels/call\-for\-testing\)**
 If you are a feature implementer and would like your RFC to appear on the above list, add the new call\-for\-testing label to your RFC along with a comment providing testing instructions and/or guidance on which aspect\(s\) of the feature need testing\.
 
 📰 **CALL FOR PARTICIPATION; PROJECTS AND SPEAKERS** 📰
+
 **CFP \- Projects**
 • [Continuwuity \- Default room ACLs](https://forgejo.ellis.link/continuwuation/continuwuity/issues/775)
 • [Continuwuity \- Ability to entirely disable typing and read receipts](https://forgejo.ellis.link/continuwuation/continuwuity/issues/821)
 • [Continuwuity \- bug: appservice users are not created on registration](https://forgejo.ellis.link/continuwuation/continuwuity/issues/813)
 • [Continuwuity \- Invite filtering / disable invites per account](https://forgejo.ellis.link/continuwuation/continuwuity/issues/836)
+
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -24,9 +24,11 @@ Summary:
 | All ❌✅ \(primary\)              | 1\.0%   | \[\-7\.3%, 9\.1%\]    | 125   |
 2 Regressions, 4 Improvements, 10 Mixed; 7 of them in rollups 40 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/a63db4d1799853b334e4106d914fba24e49c8782/triage/2025/2025-06-24.md)
+
 **\[Approved RFCs\]\(https://github\.com/rust\-lang/rfcs/commits/master\)**
 Changes to Rust follow the Rust [RFC \(request for comments\) process](https://github.com/rust-lang/rfcs#rust-rfcs)\. These are the RFCs that were approved for implementation this week:
 • No RFCs were approved this week\.
+
 **Final Comment Period**
 Every week, [the team](https://www.rust-lang.org/team.html) announces the 'final comment period' for RFCs and key PRs which are reaching a decision\. Express your opinions now\.
 

--- a/tests/expected/expected5.md
+++ b/tests/expected/expected5.md
@@ -4,5 +4,6 @@
 • [RFC: \-\-crate\-attr](https://github.com/rust-lang/rfcs/pull/3791)
 No Items entered Final Comment Period this week for [Cargo](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Reference](https://github.com/rust-lang/reference/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc), [Language Team](https://github.com/rust-lang/lang-team/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc+) or [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen+label%3Afinal-comment-period+sort%3Aupdated-desc)\.
 Let us know if you would like your PRs, Tracking Issues or RFCs to be tracked as a part of this list\.
+
 **\[New and Updated RFCs\]\(https://github\.com/rust\-lang/rfcs/pulls\)**
 • No New or Updated RFCs were created this week\.


### PR DESCRIPTION
## Summary
- adjust `format_subheading` so all subheadings start on a new line
- handle newline-prefixed CFP headers
- regenerate expected output files
- tweak `.gitignore`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --test-threads=1`
- `cargo machete` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_686a6be518488332ab36c4cd7b705af7