### PR TITLE
docs: clarify workflow toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The parser now derives the HTML link from the issue number and date and appends 
 
 ## Toolchain
 
-The project requires **Rust 1.88.0** and `rustfmt` **1.8.0**. The `rust-toolchain.toml` file pins the channel and lists the mandatory `clippy` and `rustfmt` components so `rustup` always uses the correct versions. If these components are not installed automatically, run:
+The project requires **Rust 1.88.0** and `rustfmt` **1.8.0**. The `rust-toolchain.toml` file pins the channel and lists the mandatory `clippy` and `rustfmt` components so `rustup` always uses the correct versions. All GitHub Actions workflows are configured with the same toolchain version. If these components are not installed automatically, run:
 
 ```bash
 rustup component add clippy rustfmt


### PR DESCRIPTION
## Summary
- document that CI uses the same Rust toolchain version

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686a91311d288332b0dd258a2e152566