### PR TITLE
Log chat id when sending posts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,7 @@ pub fn main() -> std::io::Result<()> {
     }
     if let (Ok(token), Ok(chat_id)) = (env::var("TELEGRAM_BOT_TOKEN"), env::var("TELEGRAM_CHAT_ID"))
     {
+        log::debug!("chat id: {chat_id}");
         let base = env::var("TELEGRAM_API_BASE")
             .unwrap_or_else(|_| "https://api.telegram.org".to_string());
         let pin_first = env::var("TELEGRAM_PIN_FIRST")


### PR DESCRIPTION
## Summary
- log chat ID before invoking `send_to_telegram`

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_686ab292d3b08332babe5ea3f6548610