### PR TITLE
Improve Telegram error logs

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -631,7 +631,14 @@ pub fn send_to_telegram(
                 .get("description")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            error!("Telegram error for post {} {}: {}", i + 1, code, desc);
+            error!(
+                "Telegram error for post {} {}: {} (status {})",
+                i + 1,
+                code,
+                desc,
+                status.as_u16()
+            );
+            error!("Full response: {body}");
             return Err(format!("Telegram API error in post {} {}: {}", i + 1, code, desc).into());
         }
         info!("Post {} sent", i + 1);


### PR DESCRIPTION
## Summary
- add HTTP status and full response body to Telegram error logs

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686adb0629b88332a563a66748791f99