### PR TITLE
Limit check-docs to docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ in the crate. The resulting array is available as `twir_deploy_notify::posts::PO
 Continuous integration runs `cargo machete` to verify that `Cargo.toml` lists only used dependencies. Run this command locally before opening a pull request.
 Install it with `cargo install cargo-machete` if it is not available.
 
-Documentation Markdown is validated with `cargo run --bin check-docs`, which parses files using [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark).
+Documentation in `DOCS/` is validated with `cargo run --bin check-docs`, which parses files using [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark).
 Generated Telegram posts are verified with the shared `validator` module.
 Integration tests that send messages to Telegram run only when the CI workflow is manually triggered with the `run_integration` input.
 

--- a/src/bin/check_docs.rs
+++ b/src/bin/check_docs.rs
@@ -38,7 +38,7 @@ fn function_exists(name: &str) -> std::io::Result<bool> {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut missing = Vec::new();
 
-    for entry in WalkDir::new(".").into_iter().filter_map(Result::ok) {
+    for entry in WalkDir::new("DOCS").into_iter().filter_map(Result::ok) {
         if entry.path().extension().and_then(|e| e.to_str()) == Some("md") {
             let content = fs::read_to_string(entry.path())?;
             let parser = Parser::new(&content);


### PR DESCRIPTION
## Summary
- scan only DOCS/ in `check_docs`
- clarify README about validating docs

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686b87a4be98833291c525876ed68f7e