### PR TITLE
Remove TELEGRAM_PIN_FIRST env variable

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -57,7 +57,6 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.DEV_TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.DEV_TELEGRAM_CHAT_ID }}
-          TELEGRAM_PIN_FIRST: '1'
         run: |
           rm -f output_*.md
           cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
@@ -83,7 +82,6 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          TELEGRAM_PIN_FIRST: '1'
         run: |
           cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Telegram:
 - `TELEGRAM_BOT_TOKEN` – the bot token used for authentication.
 - `TELEGRAM_CHAT_ID` – the identifier of the chat or channel. Numeric IDs are
   automatically prefixed with `-100` when sending requests to Telegram.
-- `TELEGRAM_PIN_FIRST` – set to `1` or `true` to pin the first sent message.
-  The service message about the pin will be deleted automatically.
+
+The first sent message is automatically pinned, and the service notification is
+removed.
 The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.
 
 Responses from Telegram are verified with the `verify-posts` binary.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,11 +43,8 @@ pub fn main() -> std::io::Result<()> {
         log::debug!("chat id: {chat_id}");
         let base = env::var("TELEGRAM_API_BASE")
             .unwrap_or_else(|_| "https://api.telegram.org".to_string());
-        let pin_first = env::var("TELEGRAM_PIN_FIRST")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
         log::info!("Sending posts to Telegram");
-        send_to_telegram(&posts, &base, &token, &chat_id, !cli.plain, pin_first)
+        send_to_telegram(&posts, &base, &token, &chat_id, !cli.plain, true)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
     } else {
         log::info!("TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; skipping send");


### PR DESCRIPTION
## Summary
- always pin the first Telegram message
- update workflow and docs accordingly

## Testing
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686b81fdddfc83329afc8137c552c744