### PR TITLE
Update AGENT instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,21 +4,13 @@
 - All code comments and technical documentation must be written in English.
 - Interpret user questions as tasks whenever possible and prefer providing a full merge request solution instead of a short code snippet.
 - Install required Rust components with `rustup component add clippy rustfmt`.
-- After making any changes, run `cargo fmt --all`, `cargo check --all-targets --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`.
+- After making any changes, run `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`.
 - Before creating a pull request, also run `cargo machete` to ensure there are no unused dependencies.
 - Review `DOCS/ARCHITECTURE.md` before starting work and verify final changes match the documented design.
 - Fix every issue reported by these commands before committing or submitting pull requests.
-- A pull request is complete only when formatting, linting, `cargo check`, and tests all succeed.
+- A pull request is complete only when formatting, linting, tests, and `cargo machete` all succeed.
 - Configure the remote `origin` as `https://github.com/qqrm/twir-deploy-notify`.
-- Before beginning or finalizing work on a task, run `git fetch origin` and
-  check whether `origin/main` contains new commits. Rebase your branch onto the
-  latest `origin/main` if needed so all development starts from the most recent
-  commit.
-- If the task includes the word "рестарт" or `Restart`, create a **task stub**
-  from the most recent `origin/main` commit. The stub repeats the current task's
-  requirements and launches a new merge request, leaving the previous branch
-  untouched. Prompt the user before continuing.
-- Read all Markdown (`*.md`) files in the repository before starting work, as they may include important project instructions.
+- Read all Markdown (`*.md`) files from the `.docs` directory before starting work. Markdown in tests can be ignored.
 - Follow the guidelines in `DOCS/PARSING.md`, especially the requirement to rely on crates for Markdown processing instead of custom parsing code.
 
 - Avoid committed dead code; remove unused functions or feature-gate them.

--- a/DOCS/RESTART.md
+++ b/DOCS/RESTART.md
@@ -1,9 +1,0 @@
-# Restart Command
-
-The repository uses an AI agent to generate merge requests. When the `Restart` command is issued, the agent copies the description of the current task and prepares a new **task stub** based on the freshest `main` commit. The agent then prints:
-
-```
-Task restarted as a stub from the latest commit. Launch it? (Yes/No)
-```
-
-Confirming will run the workflow manually on the fresh commit, avoiding merge conflicts.

--- a/README.md
+++ b/README.md
@@ -85,14 +85,6 @@ cargo test --features integration
 
 If these variables are absent, the Telegram tests are skipped.
 
-## Restart command
-
-To restart a task, use the `Restart` command. The agent duplicates the original
-task description and prepares a **task stub** that starts from the freshest
-commit on `main`. A prompt asks whether to launch the stub as a new merge
-request, avoiding stale branches. See [RESTART.md](DOCS/RESTART.md) for details.
-
-
 ## License
 
 This project is distributed under the "QQRM LAPOCHKA v1.0 License (AI-first Vibecoder)" in `LICENSE_QQRM_LAPOCHKA`.


### PR DESCRIPTION
## Summary
- update AGENTS.md instructions to remove `cargo check`, `git fetch`, and `Restart`
- drop obsolete Restart command docs
- remove Restart section from README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686b8672cf008332bfb1af569656f459