### PR TITLE
Fix CFP guidelines link

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -28,7 +28,8 @@ pub static SUBHEADING_EMOJIS: phf::Map<&'static str, &'static str> = phf_map! {
 };
 
 /// Short URL guiding contributors how to submit CFP tasks.
-const CFP_GUIDELINES: &str = "https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines";
+const CFP_GUIDELINES: &str =
+    "https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines";
 
 fn simplify_cfp_section(section: &mut Section) {
     let mut cleaned = Vec::new();

--- a/tests/expected/606_2.md
+++ b/tests/expected/606_2.md
@@ -12,4 +12,4 @@ No Calls for participation were submitted this week\.
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
-На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines)
+На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines)

--- a/tests/expected/607_2.md
+++ b/tests/expected/607_2.md
@@ -12,4 +12,4 @@ No Calls for participation were submitted this week\.
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
-На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines)
+На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines)

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -6,6 +6,6 @@ No Calls for participation were submitted this week\.
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
-На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines)
+На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines)
 
 🌐 [View web version](https://this-week-in-rust.org/blog/2025/07/05/this-week-in-rust-607/) 🌐


### PR DESCRIPTION
## Summary
- update the CFP guidelines constant URL
- refresh expected output files to match the new URL

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686baa25dce883328baac61e6c1456e7