### PR TITLE
Translate CFP message to English

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -72,7 +72,7 @@ fn simplify_cfp_section(section: &mut Section) {
 
     if !has_task {
         let msg = format!(
-            "На этой неделе новых задач нет\\. [Инструкции]({})",
+            "No new tasks this week\\. [Instructions]({})",
             escape_markdown_url(CFP_GUIDELINES)
         );
         cleaned.push(msg);

--- a/tests/cfp_regression.rs
+++ b/tests/cfp_regression.rs
@@ -78,7 +78,7 @@ fn cfp_without_tasks_inserts_message() {
     let input = format!("Title: Test\nNumber: 1\nDate: 2025-07-05\n\n{CFP_EMPTY_SNIPPET}");
     let posts = generate_posts(input).unwrap();
     let combined = posts.join("\n");
-    assert!(combined.contains("На этой неделе новых задач нет"));
+    assert!(combined.contains("No new tasks this week"));
     for post in posts {
         common::assert_valid_markdown(&post);
     }
@@ -89,7 +89,7 @@ fn cfp_with_tasks_does_not_insert_message() {
     let input = format!("Title: Test\nNumber: 1\nDate: 2025-06-25\n\n{CFP_SNIPPET}");
     let posts = generate_posts(input).unwrap();
     let combined = posts.join("\n");
-    assert!(!combined.contains("На этой неделе новых задач нет"));
+    assert!(!combined.contains("No new tasks this week"));
     for post in posts {
         common::assert_valid_markdown(&post);
     }

--- a/tests/expected/606_2.md
+++ b/tests/expected/606_2.md
@@ -12,4 +12,4 @@ No Calls for participation were submitted this week\.
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
-На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines)
+No new tasks this week\. [Instructions](https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines)

--- a/tests/expected/607_2.md
+++ b/tests/expected/607_2.md
@@ -12,4 +12,4 @@ No Calls for participation were submitted this week\.
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
-На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines)
+No new tasks this week\. [Instructions](https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines)

--- a/tests/expected/cfp1.md
+++ b/tests/expected/cfp1.md
@@ -6,6 +6,6 @@ No Calls for participation were submitted this week\.
 **CFP \- Events**
 No Calls for papers or presentations were submitted this week\.
 If you are an event organizer hoping to expand the reach of your event, please submit a link to the website through a [PR to TWiR](https://github.com/rust-lang/this-week-in-rust) or by reaching out on [X \(formerly Twitter\)](https://x.com/ThisWeekInRust) or [Mastodon](https://mastodon.social/@thisweekinrust)\!
-На этой неделе новых задач нет\. [Инструкции](https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines)
+No new tasks this week\. [Instructions](https://github.com/rust-lang/this-week-in-rust#call-for-participation-guidelines)
 
 🌐 [View web version](https://this-week-in-rust.org/blog/2025/07/05/this-week-in-rust-607/) 🌐


### PR DESCRIPTION
## Summary
- translate the "no tasks" CFP message to English
- update regression test expectations and expected output

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_686bb3347ef483329569e244d0cddf55