### PR TITLE
Update roadmap for Telegram Markdown workflow

### DIFF
--- a/DOCS/ROADMAP.md
+++ b/DOCS/ROADMAP.md
@@ -1,10 +1,10 @@
 # Project Roadmap
 
-This document outlines the major ongoing directions for development.
+This roadmap focuses on transforming "This Week in Rust" posts into valid Telegram messages.
 
-- Replace unnecessary uses of `regex` with simpler code where possible.
-- Expand tests to cover Markdown edge cases.
-- Improve CI checks, including a `cargo machete` step.
-- Plan and evaluate potential new features.
-- Precompute message conversion during compilation by parsing the Markdown
-  file at build time so the final binary already contains ready-to-send posts.
+- Parse the Markdown source with `pulldown-cmark` and split it into sections.
+- Store each block (headings, lists, paragraphs, code) in dedicated structs for easier conversion.
+- Convert those structs to Telegram Markdown using `teloxide` escaping helpers.
+- Validate every generated post through `validator::validate_telegram_markdown` before sending.
+- Provide thorough unit tests for each component and optional integration tests with Telegram.
+- Run `cargo fmt`, `cargo clippy`, `cargo test`, and `cargo machete` in CI to detect issues early.


### PR DESCRIPTION
## Summary
- simplify ROADMAP
- show steps for structured Markdown conversion to Telegram

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686bb73f12848332a4e61eb794262c50