### PR TITLE
Fix retro workflow name

### DIFF
--- a/.github/workflows/retro.yml
+++ b/.github/workflows/retro.yml
@@ -1,4 +1,4 @@
-name: Retro TWIR Processing
+name: Retro TWIR Summary
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- adjust GitHub Actions workflow name for retro processing

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_686bbf095cac83329eb40030f02c5b82