### PR TITLE
Improve telegram markdown validator

### DIFF
--- a/build_modules/validator.rs
+++ b/build_modules/validator.rs
@@ -69,6 +69,13 @@ pub fn validate_telegram_markdown(text: &str) -> Result<(), MarkdownError> {
                 if i + 1 < chars.len() && chars[i + 1] == '|' {
                     i += 1;
                     toggle_token("||", &mut stack)?;
+                } else if !in_code_block {
+                    let prev = if i == 0 { None } else { Some(chars[i - 1]) };
+                    if prev != Some('\\') {
+                        return Err(MarkdownError::InvalidEscape(format!(
+                            "Unescaped {ch} at {i}"
+                        )));
+                    }
                 }
             }
             '`' => {
@@ -108,6 +115,16 @@ pub fn validate_telegram_markdown(text: &str) -> Result<(), MarkdownError> {
                 }
                 i = j;
             }
+            ']' => {
+                if !in_code_block {
+                    let prev = if i == 0 { None } else { Some(chars[i - 1]) };
+                    if prev != Some('\\') {
+                        return Err(MarkdownError::InvalidEscape(format!(
+                            "Unescaped {ch} at {i}"
+                        )));
+                    }
+                }
+            }
             '\\' => {
                 i += 1; // skip escaped char
             }
@@ -125,6 +142,16 @@ pub fn validate_telegram_markdown(text: &str) -> Result<(), MarkdownError> {
                     return Err(MarkdownError::InvalidEscape(format!(
                         "Unescaped {ch} at {i}"
                     )));
+                }
+            }
+            '(' | ')' => {
+                if !in_code_block {
+                    let prev = if i == 0 { None } else { Some(chars[i - 1]) };
+                    if prev != Some('\\') {
+                        return Err(MarkdownError::InvalidEscape(format!(
+                            "Unescaped {ch} at {i}"
+                        )));
+                    }
                 }
             }
             _ => {}

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -826,9 +826,9 @@ mod tests {
     fn table_rendering() {
         let input = "Title: Test\nNumber: 1\nDate: 2024-01-01\n\n## Table\n| Name | Score |\n|------|------|\n| Foo | 10 |\n| Bar | 20 |\n";
         let posts = generate_posts(input.to_string()).unwrap();
-        assert!(posts[0].contains("| Name | Score |"));
-        assert!(posts[0].contains("| Foo  | 10    |"));
-        assert!(posts[0].contains("| Bar  | 20    |"));
+        assert!(posts[0].contains("\\| Name \\| Score \\|"));
+        assert!(posts[0].contains("\\| Foo  \\| 10    \\|"));
+        assert!(posts[0].contains("\\| Bar  \\| 20    \\|"));
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -181,10 +181,10 @@ pub fn parse_sections(text: &str) -> Vec<Section> {
                         }
                     }
                     for r in table.drain(..) {
-                        let mut line = String::from("|");
+                        let mut line = String::from("\\|");
                         for (i, cell) in r.into_iter().enumerate() {
                             let width = widths[i];
-                            line.push_str(&format!(" {cell:width$} |"));
+                            line.push_str(&format!(" {cell:width$} \\|"));
                         }
                         sec.lines.push(line);
                     }

--- a/tests/expected/complex1.md
+++ b/tests/expected/complex1.md
@@ -21,8 +21,8 @@ fn greet() {
 ```
 
 📰 **TABLE EXAMPLE** 📰
-| Short | Much Longer Column | C  |
-| 1     | a                  | 3  |
-| 2     | abcdef             | 44 |
+\| Short \| Much Longer Column \| C  \|
+\| 1     \| a                  \| 3  \|
+\| 2     \| abcdef             \| 44 \|
 
 🌐 [View web version](https://this-week-in-rust.org/blog/2025/07/10/this-week-in-rust-999/) 🌐

--- a/tests/expected/expected4.md
+++ b/tests/expected/expected4.md
@@ -16,12 +16,12 @@
 A week dominated by the landing of a large patch implementing [RFC\#3729](https://github.com/rust-lang/rfcs/pull/3729) which unfortunately introduced rather sizeable performance regressions \(avg of \~1% instruction count on 111 primary benchmarks\)\. This was deemed worth it so that the patch could land and performance could be won back in follow up PRs\.
 Triage done by [rylev](https://github.com/rylev)\. Revision range: [45acf54e\.\.42245d34](https://perf.rust-lang.org/?start=45acf54eea118ed27927282b5e0bfdcd80b7987c&end=42245d34d22ade32b3f276dcf74deb826841594c&absolute=false&stat=instructions%3Au)
 Summary:
-| \(instructions:u\)              | mean    | range                 | count |
-| Regressions ❌  \(primary\)      | 1\.1%   | \[0\.2%, 9\.1%\]      | 123   |
-| Regressions ❌  \(secondary\)    | 1\.0%   | \[0\.1%, 4\.6%\]      | 86    |
-| Improvements ✅  \(primary\)     | \-3\.8% | \[\-7\.3%, \-0\.3%\]  | 2     |
-| Improvements ✅  \(secondary\)   | \-2\.3% | \[\-18\.5%, \-0\.2%\] | 44    |
-| All ❌✅ \(primary\)              | 1\.0%   | \[\-7\.3%, 9\.1%\]    | 125   |
+\| \(instructions:u\)              \| mean    \| range                 \| count \|
+\| Regressions ❌  \(primary\)      \| 1\.1%   \| \[0\.2%, 9\.1%\]      \| 123   \|
+\| Regressions ❌  \(secondary\)    \| 1\.0%   \| \[0\.1%, 4\.6%\]      \| 86    \|
+\| Improvements ✅  \(primary\)     \| \-3\.8% \| \[\-7\.3%, \-0\.3%\]  \| 2     \|
+\| Improvements ✅  \(secondary\)   \| \-2\.3% \| \[\-18\.5%, \-0\.2%\] \| 44    \|
+\| All ❌✅ \(primary\)              \| 1\.0%   \| \[\-7\.3%, 9\.1%\]    \| 125   \|
 2 Regressions, 4 Improvements, 10 Mixed; 7 of them in rollups 40 artifact comparisons made in total
 [Full report here](https://github.com/rust-lang/rustc-perf/blob/a63db4d1799853b334e4106d914fba24e49c8782/triage/2025/2025-06-24.md)
 **[Approved RFCs](https://github.com/rust-lang/rfcs/commits/master)**


### PR DESCRIPTION
## Summary
- extend the Markdown validator with checks for parentheses, brackets and single pipes
- escape table delimiters when rendering Markdown tables
- update validator tests
- update expected outputs for integration tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=1`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_686bffb4d5708332b4db5950a5815eeb