### PR TITLE
Fix docs directory reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - Fix every issue reported by these commands before committing or submitting pull requests.
 - A pull request is complete only when formatting, linting, tests, and `cargo machete` all succeed.
 - Configure the remote `origin` as `https://github.com/qqrm/twir-deploy-notify`.
-- Read all Markdown (`*.md`) files from the `.docs` directory before starting work. Markdown in tests can be ignored.
+- Read all Markdown (`*.md`) files from the `DOCS` directory before starting work. Markdown in tests can be ignored.
 - Follow the guidelines in `DOCS/PARSING.md`, especially the requirement to rely on crates for Markdown processing instead of custom parsing code.
 
 - Avoid committed dead code; remove unused functions or feature-gate them.


### PR DESCRIPTION
## Summary
- fix root instructions to mention the `DOCS` directory

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6870f0dce7948332ad3599a18a2afd6f