### PR TITLE
Remove duplicate import in integration test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,8 +9,6 @@ mod common;
 
 #[cfg(feature = "integration")]
 fn run_single_post(input: &str, plain: bool, validate_markdown: bool) {
-    use mockito::Matcher;
-
     let dir = tempfile::tempdir().unwrap();
     let input_path = dir.path().join("input.md");
     fs::write(&input_path, input).unwrap();


### PR DESCRIPTION
## Summary
- clean up `integration.rs` by removing redundant `use mockito::Matcher` inside `run_single_post`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --features integration`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6870f0d66bd883328141590f31773104