### PR TITLE
Make cargo-audit optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
         description: "Run Telegram integration tests"
         required: false
         default: "false"
+      run_audit:
+        description: "Run cargo audit"
+        required: false
+        default: "false"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -92,6 +96,7 @@ jobs:
       - run: cargo machete
 
   audit:
+    if: github.event_name != 'pull_request' || github.event.inputs.run_audit == 'true'
     needs: machete
     runs-on: ubuntu-latest
     env:
@@ -105,7 +110,7 @@ jobs:
       - run: cargo audit --quiet
 
   check-docs:
-    needs: audit
+    needs: machete
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_PROGRESS_WHEN: never
@@ -117,7 +122,7 @@ jobs:
       - run: cargo run --quiet --bin check-docs
 
   coverage:
-    needs: [check-docs, audit]
+    needs: check-docs
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_PROGRESS_WHEN: never

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Install it with `cargo install cargo-machete` if it is not available.
 Documentation in `DOCS/` is validated with `cargo run --bin check-docs`, which parses files using [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark).
 Generated Telegram posts are verified with the shared `validator` module.
 Integration tests that send messages to Telegram run only when the CI workflow is manually triggered with the `run_integration` input.
+Security checks using `cargo-audit` can be enabled in the same way by setting the `run_audit` input.
 
 ### Running integration tests
 


### PR DESCRIPTION
## Summary
- make `cargo-audit` optional for pull requests
- allow enabling it with a `run_audit` workflow input
- document the `run_audit` option in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6870f529726483329ac37693dcd9b411