### PR TITLE
Implement cleanup of old output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ After that you can run the tool manually with:
 cargo run --bin twir-deploy-notify -- twir/content/<file-name>.md
 ```
 
+All files matching `output_*.md` in the current directory are removed before the
+new posts are written.
+
 Set `RUST_LOG=info` to see detailed logs including Telegram API responses:
 
 ```bash


### PR DESCRIPTION
## Summary
- delete existing `output_*.md` files before creating new posts
- explain cleanup behaviour in README
- test that stale files are removed

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(fails: `no such command: machete`)*

------
https://chatgpt.com/codex/tasks/task_e_687100e464948332adb715a93e8b8027