### PR TITLE
Enable auto-merge after successful checks

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["CI"]
     types:
       - completed
+  check_suite:
+    types: [completed]
 
 permissions:
   contents: write
@@ -12,7 +14,9 @@ permissions:
 
 jobs:
   merge:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +27,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.workflow_run.pull_requests[0];
+            const pr = (context.payload.workflow_run && context.payload.workflow_run.pull_requests[0]) ||
+              (context.payload.check_suite && context.payload.check_suite.pull_requests[0]);
             core.setOutput('number', pr ? pr.number : '');
+      - name: Wait for checks
+        if: steps.pr.outputs.number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: gh pr checks "$PR" --watch --required --fail-fast
       - name: Merge primary PR
         if: steps.pr.outputs.number
         env:


### PR DESCRIPTION
## Summary
- expand `automerge.yml` to react on `check_suite` completion
- verify required status checks before merging

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_68753531e7c083329c1fc1fede1c7f4d