### PR TITLE
Fix Telegram chat ID verification

### DIFF
--- a/src/generator_shared.rs
+++ b/src/generator_shared.rs
@@ -565,7 +565,8 @@ struct TelegramResponse {
     description: Option<String>,
 }
 
-fn normalize_chat_id(chat_id: &str) -> Cow<'_, str> {
+/// Normalize chat identifier to the `-100` prefix used for channels.
+pub fn normalize_chat_id(chat_id: &str) -> Cow<'_, str> {
     if chat_id.starts_with('@') || chat_id.starts_with("-100") {
         Cow::Borrowed(chat_id)
     } else {


### PR DESCRIPTION
## Summary
- make `normalize_chat_id` public for reuse
- apply chat ID normalization in `verify_posts` when checking updates

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6874ea7a06288332b06979ae8217230b