### PR TITLE
Improve automerge workflow status checks

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -15,8 +15,14 @@ permissions:
 jobs:
   merge:
     if: >-
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success')
+      (github.event_name == 'workflow_run' &&
+        (github.event.workflow_run.conclusion == 'success' ||
+         github.event.workflow_run.conclusion == 'skipped' ||
+         github.event.workflow_run.conclusion == 'neutral')) ||
+      (github.event_name == 'check_suite' &&
+        (github.event.check_suite.conclusion == 'success' ||
+         github.event.check_suite.conclusion == 'skipped' ||
+         github.event.check_suite.conclusion == 'neutral'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,10 +38,39 @@ jobs:
             core.setOutput('number', pr ? pr.number : '');
       - name: Wait for checks
         if: steps.pr.outputs.number
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = process.env.PR_NUMBER;
+            const { owner, repo } = context.repo;
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const ref = pr.data.head.sha;
+            const branch = pr.data.base.ref;
+            const protection = await github.request(
+              'GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks',
+              { owner, repo, branch }
+            );
+            const required = protection.data.contexts;
+            const wait = ms => new Promise(r => setTimeout(r, ms));
+
+            for (const ctx of required) {
+              while (true) {
+                const checks = await github.rest.checks.listForRef({ owner, repo, ref, check_name: ctx });
+                const run = checks.data.check_runs[0];
+                const conclusion = run?.conclusion;
+                if (!conclusion || conclusion === 'queued' || conclusion === 'in_progress') {
+                  await wait(5000);
+                  continue;
+                }
+                if (conclusion !== 'success' && conclusion !== 'skipped') {
+                  core.setFailed(`Required check ${ctx} concluded with ${conclusion}`);
+                }
+                break;
+              }
+            }
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.pr.outputs.number }}
-        run: gh pr checks "$PR" --watch --required --fail-fast
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
       - name: Merge primary PR
         if: steps.pr.outputs.number
         env:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Generated Telegram posts are verified with the shared `validator` module.
 Integration tests that send messages to Telegram run only when the CI workflow is manually triggered with the `run_integration` input.
 Security checks using `cargo-audit` can be enabled in the same way by setting the `run_audit` input.
 
+### Auto merge
+
+Pull requests targeting the `main` branch are merged automatically once all required
+CI checks complete. The `automerge.yml` workflow retrieves the list of required
+check runs via `gh api` and waits until each one finishes. The job succeeds
+if every required check reports the `success` or `skipped` conclusion, allowing
+partially skipped pipelines to be merged.
+
 ### Running integration tests
 
 The integration suite relies on the [`mockito`](https://crates.io/crates/mockito) crate to mock network requests.


### PR DESCRIPTION
## Summary
- allow automerge trigger on success, skipped and neutral check suites
- poll check runs with `github-script` and accept `success` or `skipped`
- document the new auto merge behaviour in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6875c548436883329f739749f687eaa0