### PR TITLE
Document pipelines and rename workflows

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,8 +1,8 @@
-name: Auto merge
+name: TWIR Auto merge
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["TWIR CI"]
     types:
       - completed
   check_suite:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,4 +1,4 @@
-name: Cancel PR CI
+name: TWIR Cancel CI
 
 on:
   pull_request:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,4 +1,4 @@
-name: Delete merged branches
+name: TWIR Delete merged branches
 
 on:
   pull_request:

--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -1,4 +1,4 @@
-name: Common TWIR delivery
+name: TWIR Common delivery
 
 on:
   workflow_call:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,4 +1,4 @@
-name: Dev TWIR summary
+name: TWIR Dev summary
 
 on:
   workflow_dispatch:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: TWIR Integration tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -1,4 +1,4 @@
-name: Prune old workflow runs
+name: TWIR Prune old workflow runs
 
 on:
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release TWIR summary
+name: TWIR Release summary
 
 on:
   schedule:

--- a/.github/workflows/retro.yml
+++ b/.github/workflows/retro.yml
@@ -1,4 +1,4 @@
-name: Retro TWIR Summary
+name: TWIR Retro summary
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: TWIR CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ The `release.yml` workflow runs on a daily schedule at 09:00 UTC. It first sends
 posts to the development chat and, once verified, delivers the same release to the
 main chat. The `dev.yml` workflow is triggered manually for integration tests.
 
+The `integration-tests.yml` workflow runs the integration suite with real
+Telegram credentials and can be started manually. The `retro.yml` workflow
+builds posts for the last ten issues and uploads them as artifacts.
+
 Setting the `TWIR_MARKDOWN` environment variable before building will
 parse the referenced file at compile time and embed the generated posts
 in the crate. The resulting array is available as `twir_deploy_notify::posts::POSTS`.
@@ -73,7 +77,7 @@ Install it with `cargo install cargo-machete` if it is not available.
 
 Documentation in `DOCS/` is validated with `cargo run --bin check-docs`, which parses files using [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark).
 Generated Telegram posts are verified with the shared `validator` module.
-Integration tests that send messages to Telegram run only when the CI workflow is manually triggered with the `run_integration` input.
+Integration tests that send messages to Telegram run only when the TWIR CI workflow is manually triggered with the `run_integration` input.
 Security checks using `cargo-audit` can be enabled in the same way by setting the `run_audit` input.
 
 ### Auto merge


### PR DESCRIPTION
## Summary
- mention extra GitHub Actions in the README
- rename all workflow `name` fields to a unified style

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68764e852eac83329d4604e4b2f99c4d