### PR TITLE
Improve output generation logging

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,9 +35,6 @@ pub fn main() -> std::io::Result<()> {
 
     log::info!("Writing posts to disk");
     write_posts(&posts, Path::new("."))?;
-    for (i, _) in posts.iter().enumerate() {
-        println!("Generated output_{}.md", i + 1);
-    }
     if let (Ok(token), Ok(chat_id)) = (env::var("TELEGRAM_BOT_TOKEN"), env::var("TELEGRAM_CHAT_ID"))
     {
         log::debug!("chat id: {chat_id}");

--- a/src/shared/generator_shared.rs
+++ b/src/shared/generator_shared.rs
@@ -552,6 +552,9 @@ pub fn write_posts(posts: &[String], dir: &Path) -> std::io::Result<()> {
     for (i, post) in posts.iter().enumerate() {
         let file_name = dir.join(format!("output_{}.md", i + 1));
         fs::write(&file_name, post)?;
+        if let Some(name) = file_name.file_name() {
+            println!("Generated {}", name.to_string_lossy());
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- print success message inside `write_posts`
- remove redundant loop in CLI

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687654bbc45483328f325958be02b4db