### PR TITLE
Make coverage optional in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,8 +122,10 @@ jobs:
       - run: cargo run --quiet --bin check-docs
 
   coverage:
+    if: github.event_name != 'pull_request'
     needs: check-docs
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:


### PR DESCRIPTION
## Summary
- don't run coverage in PRs by default
- allow CI pipeline to succeed even if coverage fails

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet --all-targets --all-features -- --test-threads=$(nproc)`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_687656a788c08332a8bb4cea4d4a7781