### PR TITLE
Remove invalid env from dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,5 +16,3 @@ jobs:
     with:
       send_main: false
       run_integration: true
-    env:
-      RUST_LOG: debug


### PR DESCRIPTION
## Summary
- fix the `TWIR Dev summary` workflow by removing an unsupported `env` block

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo install cargo-machete --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68765951c25c833281d8d4cf72f2357e