### PR TITLE
Serialize integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,10 @@ name: TWIR Integration tests
 on:
   workflow_dispatch:
 
+concurrency:
+  group: integration-tests
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- prevent concurrent integration test workflow runs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68765e934eb88332a887f3a8da397c0e