### PR TITLE
Validate Telegram credentials

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,8 +35,13 @@ pub fn main() -> std::io::Result<()> {
 
     log::info!("Writing posts to disk");
     write_posts(&posts, Path::new("."))?;
-    if let (Ok(token), Ok(chat_id)) = (env::var("TELEGRAM_BOT_TOKEN"), env::var("TELEGRAM_CHAT_ID"))
-    {
+    let token = env::var("TELEGRAM_BOT_TOKEN")
+        .ok()
+        .filter(|t| !t.trim().is_empty());
+    let chat_id = env::var("TELEGRAM_CHAT_ID")
+        .ok()
+        .filter(|c| !c.trim().is_empty());
+    if let (Some(token), Some(chat_id)) = (token, chat_id) {
         log::debug!("chat id: {chat_id}");
         let base = env::var("TELEGRAM_API_BASE")
             .unwrap_or_else(|_| "https://api.telegram.org".to_string());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -621,3 +621,25 @@ fn send_to_telegram_rejects_invalid_before_request() {
     assert!(result.is_err());
     m.assert();
 }
+
+#[test]
+fn cli_skips_send_when_vars_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = "Title: Test\nNumber: 1\nDate: 2025-01-01\n\n## News\n- item\n";
+    let input_path = dir.path().join("input.md");
+    fs::write(&input_path, input).unwrap();
+
+    let mut server = mockito::Server::new();
+    let m = server.mock("POST", "/bot/sendMessage").expect(0).create();
+
+    let status = Command::new(env!("CARGO_BIN_EXE_twir-deploy-notify"))
+        .arg(&input_path)
+        .current_dir(dir.path())
+        .env("TELEGRAM_BOT_TOKEN", "")
+        .env("TELEGRAM_CHAT_ID", "")
+        .env("TELEGRAM_API_BASE", server.url())
+        .status()
+        .expect("failed to run binary");
+    assert!(status.success());
+    m.assert();
+}


### PR DESCRIPTION
## Summary
- avoid trying to send Telegram posts when credentials are empty
- test that sending is skipped when credentials are empty

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6876612361308332846db8732adba0d2