### PR TITLE
Condense architecture docs

### DIFF
--- a/DOCS/ARCHITECTURE.md
+++ b/DOCS/ARCHITECTURE.md
@@ -1,32 +1,28 @@
-# Project Architecture
+# Architecture Overview
 
-This tool processes weekly "This Week in Rust" Markdown files and prepares messages for Telegram.
+The crate turns "This Week in Rust" Markdown into Telegram posts.
 
-## Structure
-- **src/main.rs**: Entry point that calls into the CLI module.
-- **src/cli.rs**: Parses command-line arguments and orchestrates the workflow.
-- **src/shared/**: Shared implementation of the generator, parser and validator.
-- **src/generator.rs**: Re-exports the generator functions.
-- **src/parser.rs**: Re-exports the parser implementation.
-- **src/validator.rs**: Re-exports the validator logic.
-- **Cargo.toml**: Defines dependencies such as `pulldown-cmark` and `teloxide`.
-- **last_sent.txt**: Records the last processed issue for the workflow.
-- **src/bin/verify_posts.rs**: Sends posts to Telegram and confirms that they
-  were delivered correctly.
+## Layout
+- `src/main.rs` – CLI entrypoint.
+- `src/cli.rs` – parses arguments and triggers post generation.
+- `src/shared/` – parser, generator and validator used by the library and build script.
+- `src/generator.rs`, `src/parser.rs`, `src/validator.rs` – thin re-exports of shared modules.
+- `src/bin/verify_posts.rs` – checks posts by sending them to Telegram.
+- `build.rs` – embeds posts when `TWIR_MARKDOWN` is set; output is included via `src/posts.rs`.
+- `last_sent.txt` – workflow artifact with the last processed issue.
 
-## Parsing Flow
-1. The input Markdown includes metadata lines beginning with `Title:`, `Number:`, and `Date:`.
-2. `pulldown-cmark` parses the rest of the file into sections based on `##` headings and list items.
-3. Each list item is converted to Telegram Markdown while escaping special characters.
-4. Links are preserved using parentheses format, and a final link to the full issue is generated from the date and number.
+## Processing
+1. Markdown files start with `Title:`, `Number:` and `Date:` lines.
+2. `pulldown-cmark` splits the rest into sections using `##` headings and list items.
+3. Each item becomes Telegram Markdown with special characters escaped.
+4. A final link to the web version is derived from the date and number.
 
-## Message Generation
-- Each section becomes a separate Telegram post capped at 4000 characters.
-- Long messages are split by `split_posts`, which scans for escaped characters when breaking lines so that Telegram accepts every chunk. Every post after the first is prefixed with `*Part X/Y*`, where `X` and `Y` are plain digits.
-- The issue title in the first post is surrounded by crab emojis.
-- The optional `--plain` flag removes Markdown formatting for channels that require plain text.
+## Posts
+- Each section forms a post capped at 4000 characters.
+- `split_posts` divides long messages and prefixes later posts with `*Part X/Y*`.
+- The `--plain` flag strips formatting for plain text destinations.
 
-## Dependencies
-- `pulldown-cmark` handles Markdown parsing.
-- `teloxide` utilities assist with escaping text for Telegram Markdown.
+## Key crates
+- `pulldown-cmark` for Markdown parsing.
+- `teloxide` and `reqwest` for Telegram interactions.
 


### PR DESCRIPTION
## Summary
- shorten `DOCS/ARCHITECTURE.md`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68766f830f688332867f884adf873840