### PR TITLE
Disable integration tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.88.0
-      - run: cargo test --quiet --all-targets --all-features -- --test-threads=$(nproc)
+      - run: cargo test --quiet --lib --bins --all-features -- --test-threads=$(nproc)
 
   machete:
     needs: test


### PR DESCRIPTION
## Summary
- stop running integration tests in the CI workflow

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet --lib --bins --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68766e5c173483329dd85e6a3346d4bb