### PR TITLE
Update release workflow schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: TWIR Release summary
 
 on:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ removed.
 The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.
 
 Responses from Telegram are verified with the `verify-posts` binary.
-The `release.yml` workflow runs on a daily schedule at 09:00 UTC. It first sends the
+The `release.yml` workflow runs hourly on the zeroth minute. It first sends the
 posts to the development chat and, once verified, delivers the same release to the
 main chat. The `retro.yml` workflow builds posts for the last ten issues and uploads
 them as artifacts.


### PR DESCRIPTION
## Summary
- update `release.yml` schedule from daily to hourly
- document new schedule in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_6877465669288332bc80a16cd9043132