### PR TITLE
Fix pipeline success with missing Telegram credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Telegram:
 - GitHub Actions expect the following secrets to populate these variables:
   `DEV_BOT_TOKEN`, `DEV_CHAT_ID`, `RELEASE_BOT_TOKEN`, and `RELEASE_CHAT_ID`.
 
+If either variable is missing, the program terminates with a non-zero exit code
+to ensure that automated workflows fail early.
+
 The first sent message is automatically pinned, and the service notification is
 removed.
 The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use clap::Parser as ClapParser;
-use std::{env, fs, path::Path};
+use std::{env, fs, io, path::Path};
 
 use crate::generator::{generate_posts, markdown_to_plain, send_to_telegram, write_posts};
 
@@ -47,9 +47,13 @@ pub fn main() -> std::io::Result<()> {
             .unwrap_or_else(|_| "https://api.telegram.org".to_string());
         log::info!("Sending posts to Telegram");
         send_to_telegram(&posts, &base, &token, &chat_id, !cli.plain, true)
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
+            .map_err(|e| io::Error::other(e.to_string()))?;
     } else {
-        log::info!("TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; skipping send");
+        log::error!("TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; aborting");
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "Telegram credentials missing",
+        ));
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- exit with an error when Telegram credentials are absent
- mention non-zero exit in README

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68774eec43648332ae8b5ddb6dd4e92c