### PR TITLE
Ensure workflow secrets match repository

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Send to main chat
         if: steps.prepare.outputs.send == 'true' && inputs.send_main == true
         env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.RELEASE_CHAT_ID }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Telegram:
 - `TELEGRAM_CHAT_ID` – the identifier of the chat or channel. Numeric IDs are
   automatically prefixed with `-100` when sending requests to Telegram.
 - GitHub Actions expect the following secrets to populate these variables:
-  `DEV_BOT_TOKEN`, `DEV_CHAT_ID`, `RELEASE_BOT_TOKEN`, and `RELEASE_CHAT_ID`.
+  `DEV_BOT_TOKEN`, `DEV_CHAT_ID`, `TELEGRAM_BOT_TOKEN`, and `TELEGRAM_CHAT_ID`.
 
 If either variable is missing, the program terminates with a non-zero exit code
 to ensure that automated workflows fail early.


### PR DESCRIPTION
## Summary
- match README to current secret names
- update workflow to use TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68774f8e20fc83329a5224aded36ef5a