### PR TITLE
Optimize TWIR checkout

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           repository: rust-lang/this-week-in-rust
           path: twir
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: |
+            content/
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/retro.yml
+++ b/.github/workflows/retro.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           repository: rust-lang/this-week-in-rust
           path: twir
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: |
+            content/
 
       - name: Determine last 10 posts
         id: list

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ rustup component add clippy rustfmt
 To run the workflow locally you must clone the `this-week-in-rust` repository into a `twir` subdirectory:
 
 ```bash
-git clone https://github.com/rust-lang/this-week-in-rust twir
+git clone --depth 1 --filter=blob:none --sparse \
+  https://github.com/rust-lang/this-week-in-rust twir
+cd twir && git sparse-checkout set content
+cd ..
 ```
 
 After that you can run the tool manually with:


### PR DESCRIPTION
## Summary
- speed up actions by checking out only the `content/` folder
- document partial clone instructions for local workflow runs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --bins --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68777211d54883329f705ec323bf3c1e