### PR TITLE
Rename release workflow to prod

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,4 +1,4 @@
-name: TWIR Release summary
+name: TWIR Prod summary
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -66,9 +66,7 @@ removed.
 The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.
 
 Responses from Telegram are verified with the `verify-posts` binary.
-The `release.yml` workflow runs hourly on the zeroth minute. It first sends the
-posts to the development chat and, once verified, delivers the same release to the
-main chat. The `retro.yml` workflow builds posts for the last ten issues and uploads
+The `prod.yml` workflow runs hourly on the zeroth minute. It first posts to the development chat and, once verified, delivers the release to the main chat. The `retro.yml` workflow builds posts for the last ten issues and uploads
 them as artifacts.
 
 Setting the `TWIR_MARKDOWN` environment variable before building will


### PR DESCRIPTION
## Summary
- rename release.yml to prod.yml
- update workflow name for production deployment
- replace release.yml with prod.yml in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6877ca34843083328174de56a823cabc