### PR TITLE
Improve automerge logic

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -58,28 +58,21 @@ jobs:
             const { owner, repo } = context.repo;
             const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             const ref = pr.data.head.sha;
-            const branch = pr.data.base.ref;
-            const protection = await github.request(
-              'GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks',
-              { owner, repo, branch }
-            );
-            const required = protection.data.contexts;
             const wait = ms => new Promise(r => setTimeout(r, ms));
 
-            for (const ctx of required) {
-              while (true) {
-                const checks = await github.rest.checks.listForRef({ owner, repo, ref, check_name: ctx });
-                const run = checks.data.check_runs[0];
-                const conclusion = run?.conclusion;
-                if (!conclusion || conclusion === 'queued' || conclusion === 'in_progress') {
-                  await wait(5000);
-                  continue;
-                }
-                if (conclusion !== 'success' && conclusion !== 'skipped') {
-                  core.setFailed(`Required check ${ctx} concluded with ${conclusion}`);
-                }
-                break;
+            while (true) {
+              const checks = await github.rest.checks.listForRef({ owner, repo, ref });
+              const runs = checks.data.check_runs;
+              const pending = runs.filter(r => !r.conclusion || r.conclusion === 'queued' || r.conclusion === 'in_progress');
+              if (pending.length > 0) {
+                await wait(5000);
+                continue;
               }
+              const failed = runs.find(r => !['success', 'skipped', 'neutral'].includes(r.conclusion));
+              if (failed) {
+                core.setFailed(`Check ${failed.name} concluded with ${failed.conclusion}`);
+              }
+              break;
             }
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Security checks using `cargo-audit` can be enabled in the same way by setting th
 
 ### Auto merge
 
-Pull requests targeting the `main` branch are merged automatically once all required
-CI checks complete. The `automerge.yml` workflow retrieves the list of required
-check runs via `gh api` and waits until each one finishes. The job succeeds
-if every required check reports the `success` or `skipped` conclusion, allowing
-partially skipped pipelines to be merged.
+Pull requests targeting the `main` branch are merged automatically once all CI
+checks have completed. The `automerge.yml` workflow waits for every check run on
+the pull request commit to finish and fails only if a run reports a non-success
+conclusion. Checks that are skipped or marked as neutral do not block merging,
+so partially skipped pipelines can still be merged.
 
 
 ## License


### PR DESCRIPTION
## Summary
- update README docs about auto merge
- refine `automerge.yml` workflow to wait for all check runs instead of required status list

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet --lib --bins --all-features -- --test-threads=$(nproc)`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687771b4594c83328ef1851f9ae10b58