### PR TITLE
Relax Telegram credential requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ compilations target the current machine's CPU features.
 The application expects several environment variables when sending posts to
 Telegram:
 
-- `TELEGRAM_BOT_TOKEN` – the bot token used for authentication.
-- `TELEGRAM_CHAT_ID` – the identifier of the chat or channel. Numeric IDs are
+- `TELEGRAM_BOT_TOKEN` – bot token for the main chat.
+- `TELEGRAM_CHAT_ID` – identifier of the main chat or channel. Numeric IDs are
   automatically prefixed with `-100` when sending requests to Telegram.
-- GitHub Actions expect the following secrets to populate these variables:
-  `DEV_BOT_TOKEN`, `DEV_CHAT_ID`, `TELEGRAM_BOT_TOKEN`, and `TELEGRAM_CHAT_ID`.
+- `DEV_BOT_TOKEN` and `DEV_CHAT_ID` – optional credentials used in the
+  development pipeline.
 
-If either variable is missing, the program terminates with a non-zero exit code
-to ensure that automated workflows fail early.
+The CLI first looks for `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`. If either
+is not set, it falls back to `DEV_BOT_TOKEN` and `DEV_CHAT_ID`. This allows
+running the development workflow without main chat credentials. If no valid
+credentials are found, the program only writes the generated posts to disk.
 
 The first sent message is automatically pinned, and the service notification is
 removed.


### PR DESCRIPTION
## Summary
- allow falling back to development credentials when main chat variables are missing
- document how the CLI resolves Telegram credentials

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6878117bfbf083328e0772487fdf2ba0