### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: TWIR Release
+
+on:
+  workflow_run:
+    workflows: ["TWIR CI"]
+    branches: [ main ]
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_PROGRESS_WHEN: never
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: 1.88.0
+      - run: cargo build --quiet --release
+      - name: Remove existing releases
+        run: |
+          gh release list --limit 100 --json tagName --jq '.[].tagName' | while read -r tag; do
+            gh release delete "$tag" -y
+          done
+      - name: Create latest release
+        run: |
+          gh release create latest target/release/twir-deploy-notify \
+            -t "Latest Release" -n ""

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains a small tool and workflow for sending summaries of the 
 
 The GitHub Actions workflow checks out the [`rust-lang/this-week-in-rust`](https://github.com/rust-lang/this-week-in-rust) repository and detects the newest Markdown file in its `content` directory. If a new issue is found, it is parsed with the Rust application in `src/main.rs`, and the generated message is posted to the configured Telegram chat. Each section becomes an individual Telegram post, and sections or overly long lines exceeding Telegram's size limit are automatically split.
 The parser now derives the HTML link from the issue number and date and appends it at the end of each Telegram message.
+A single GitHub release tagged `latest` always provides the most recent binary.
 
 ## Toolchain
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish the latest binary
- mention the permanent `latest` release in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68781a34057083329f870b9f04edfa0a