### PR TITLE
Fix setup-rust usage

### DIFF
--- a/.github/workflows/retro.yml
+++ b/.github/workflows/retro.yml
@@ -9,6 +9,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -33,6 +34,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -45,6 +47,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -57,6 +60,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -69,6 +73,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -83,6 +88,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -96,6 +102,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -110,6 +117,7 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:


### PR DESCRIPTION
## Summary
- checkout the repository before running composite action `setup-rust` so local actions can be found

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --bins --all-features -- --test-threads=$(nproc)`
- `cargo install cargo-machete --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68782e30593483329af61ed483280a5c