### PR TITLE
Fix reusable workflow syntax

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,11 +14,7 @@ permissions:
 jobs:
   notify:
     uses: ./.github/workflows/common-delivery.yml
-
-    environment: dev
-
     secrets: inherit
-
     with:
       send_main: false
       rust_log: debug

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -18,9 +18,6 @@ jobs:
   notify:
     uses: ./.github/workflows/common-delivery.yml
 
-    environment: prod
-
     secrets: inherit
-
     with:
       send_main: true


### PR DESCRIPTION
## Summary
- remove invalid `environment` entries from dev and prod GitHub Actions workflows

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68783022cd1083329fef80650b59e929