### PR TITLE
Fix workflow environment inputs

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -10,6 +10,9 @@ on:
         required: false
         type: string
         default: info
+      environment:
+        required: true
+        type: string
     secrets:
       TELEGRAM_BOT_TOKEN:
         required: true
@@ -19,6 +22,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     env:
       CARGO_TERM_PROGRESS_WHEN: never
       RUST_LOG: ${{ inputs.rust_log }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,8 +14,8 @@ permissions:
 jobs:
   notify:
     uses: ./.github/workflows/common-delivery.yml
-    environment: dev
     secrets: inherit
     with:
+      environment: dev
       send_main: false
       rust_log: debug

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -17,8 +17,7 @@ permissions:
 jobs:
   notify:
     uses: ./.github/workflows/common-delivery.yml
-    environment: prod
-
     secrets: inherit
     with:
+      environment: prod
       send_main: true


### PR DESCRIPTION
## Summary
- allow environment as an input for the reusable workflow
- pass environment name in prod/dev workflows

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo install cargo-machete --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6878aac8dd008332a85ca79bee8913c1