### PR TITLE
Adjust prod workflow

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -6,6 +6,10 @@ on:
       send_main:
         required: true
         type: boolean
+      send_dev:
+        required: false
+        type: boolean
+        default: true
       rust_log:
         required: false
         type: string
@@ -70,7 +74,7 @@ jobs:
           fi
 
       - name: Send to dev chat
-        if: steps.prepare.outputs.send == 'true'
+        if: steps.prepare.outputs.send == 'true' && inputs.send_dev == true
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID:  ${{ secrets.TELEGRAM_CHAT_ID }}
@@ -80,7 +84,7 @@ jobs:
           echo "${{ steps.prepare.outputs.latest_post }}" > last_sent.txt
 
       - name: Verify dev delivery
-        if: steps.prepare.outputs.send == 'true' && github.event_name == 'schedule'
+        if: steps.prepare.outputs.send == 'true' && inputs.send_dev == true && github.event_name == 'schedule'
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID:  ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -21,3 +21,4 @@ jobs:
     with:
       environment: prod
       send_main: true
+      send_dev: false

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ removed.
 The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.
 
 Responses from Telegram are verified with the `verify-posts` binary.
-The `prod.yml` workflow runs hourly on the zeroth minute. It first posts to the development chat and, once verified, delivers the release to the main chat. The `retro.yml` workflow builds posts for the last ten issues and uploads
+The `prod.yml` workflow runs hourly on the zeroth minute and publishes the latest post directly to the main chat. The `retro.yml` workflow builds posts for the last ten issues and uploads
 them as artifacts. All posts are parsed at runtime using the shared parser and generator.
 
 ## Development


### PR DESCRIPTION
## Summary
- optionally send dev chat notifications
- disable dev chat step in `prod.yml`
- update docs about prod workflow

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6878de61c3a88332a3e9843af246c1ea