### PR TITLE
Shorten column labels

### DIFF
--- a/src/shared/parser.rs
+++ b/src/shared/parser.rs
@@ -64,6 +64,8 @@ fn normalize_table_text(text: &str) -> String {
         .replace("Improvements", "Imp")
         .replace('❌', "x")
         .replace('✅', "v")
+        .replace("(primary)", "(prim)")
+        .replace("(secondary)", "(sec)")
 }
 
 /// Parse TWIR Markdown into logical sections using `pulldown-cmark`.


### PR DESCRIPTION
## Summary
- shorten `(primary)` to `(prim)` and `(secondary)` to `(sec)` when normalizing table text

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6878d6c2fe90833296f89c2e517ff9de