### PR TITLE
Fix recording of last sent issue

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -98,6 +98,7 @@ jobs:
           TELEGRAM_CHAT_ID:  ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
+          echo "${{ steps.prepare.outputs.latest_post }}" > last_sent.txt
 
       - name: Upload generated posts
         if: ${{ always() }}


### PR DESCRIPTION
## Summary
- ensure `last_sent.txt` is produced when sending to the main chat

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6878fa3424408332963d50423b9b2652