### PR TITLE
Fix last_sent marker condition

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -81,7 +81,6 @@ jobs:
         run: |
           rm -f output_*.md
           cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
-          echo "${{ steps.prepare.outputs.latest_post }}" > last_sent.txt
 
       - name: Verify dev delivery
         if: steps.prepare.outputs.send == 'true' && inputs.send_dev == true && github.event_name == 'schedule'
@@ -98,6 +97,10 @@ jobs:
           TELEGRAM_CHAT_ID:  ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           cargo run --quiet --bin twir-deploy-notify -- "${{ steps.prepare.outputs.latest_post }}"
+
+      - name: Save last_sent marker
+        if: steps.prepare.outputs.send == 'true' && inputs.send_main == true
+        run: echo "${{ steps.prepare.outputs.latest_post }}" > last_sent.txt
 
       - name: Upload generated posts
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ writes the generated posts to disk.
 
 The first sent message is automatically pinned, and the service notification is
 removed.
-The workflow stores the last processed file in `last_sent.txt` as an artifact and downloads it on the next run.
+Production runs store the last processed file in `last_sent.txt` as an artifact and download it on the next run.
 
 Responses from Telegram are verified with the `verify-posts` binary.
 The `prod.yml` workflow runs hourly on the zeroth minute and publishes the latest post directly to the main chat. The `retro.yml` workflow builds posts for the last ten issues and uploads


### PR DESCRIPTION
## Summary
- save `last_sent.txt` only when sending to the production chat
- clarify documentation about production runs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6878f9d0c1748332b9c0aed2dee56b42