### PR TITLE
Fix LastSend check for prod pipeline

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -67,7 +67,7 @@ jobs:
           latest_post=$(ls twir/content/*-this-week-in-rust*.md | sort | tail -n1)
           echo "latest_post=$latest_post" >> "$GITHUB_OUTPUT"
           last_sent=$(cat last_sent.txt 2>/dev/null || echo "")
-          if [ "$GITHUB_EVENT_NAME" != "schedule" ] || [ "$latest_post" != "$last_sent" ]; then
+          if [ "$latest_post" != "$last_sent" ]; then
             echo "send=true" >> "$GITHUB_OUTPUT"
           else
             echo "send=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- ensure `last_sent` is checked for manual prod runs as well

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6878fe4340388332bf471d29ccb6a92f