### PR TITLE
Replace primary/secondary markers

### DIFF
--- a/src/shared/parser.rs
+++ b/src/shared/parser.rs
@@ -64,8 +64,6 @@ fn normalize_table_text(text: &str) -> String {
         .replace("Improvements", "Imp")
         .replace('❌', "x")
         .replace('✅', "v")
-        .replace("(primary)", "(prim)")
-        .replace("(secondary)", "(sec)")
 }
 
 /// Parse TWIR Markdown into logical sections using `pulldown-cmark`.

--- a/tests/2025-06-25-this-week-in-rust.md
+++ b/tests/2025-06-25-this-week-in-rust.md
@@ -202,11 +202,11 @@ Revision range: [45acf54e..42245d34](https://perf.rust-lang.org/?start=45acf54ee
 
 | (instructions:u)                   | mean  | range           | count |
 |:----------------------------------:|:-----:|:---------------:|:-----:|
-| Regressions ❌ <br /> (primary)    | 1.1%  | [0.2%, 9.1%]    | 123   |
-| Regressions ❌ <br /> (secondary)  | 1.0%  | [0.1%, 4.6%]    | 86    |
-| Improvements ✅ <br /> (primary)   | -3.8% | [-7.3%, -0.3%]  | 2     |
-| Improvements ✅ <br /> (secondary) | -2.3% | [-18.5%, -0.2%] | 44    |
-| All ❌✅ (primary)                 | 1.0%  | [-7.3%, 9.1%]   | 125   |
+| Regressions ❌ <br /> (prim)    | 1.1%  | [0.2%, 9.1%]    | 123   |
+| Regressions ❌ <br /> (sec)  | 1.0%  | [0.1%, 4.6%]    | 86    |
+| Improvements ✅ <br /> (prim)   | -3.8% | [-7.3%, -0.3%]  | 2     |
+| Improvements ✅ <br /> (sec) | -2.3% | [-18.5%, -0.2%] | 44    |
+| All ❌✅ (prim)                 | 1.0%  | [-7.3%, 9.1%]   | 125   |
 
 
 2 Regressions, 4 Improvements, 10 Mixed; 7 of them in rollups

--- a/tests/regression_table.md
+++ b/tests/regression_table.md
@@ -1,5 +1,5 @@
 ## Perf
 | (instructions:u) | mean | range | count |
 |:--|:--|:--|:--|
-| Regressions ❌ <br /> (primary) | 1.1% | [0.2%, 4.3%] | 128 |
-| Improvements ✅ <br /> (secondary) | -5.1% | [-42.6%, -0.2%] | 68 |
+| Regressions ❌ <br /> (prim) | 1.1% | [0.2%, 4.3%] | 128 |
+| Improvements ✅ <br /> (sec) | -5.1% | [-42.6%, -0.2%] | 68 |


### PR DESCRIPTION
## Summary
- replace `(primary)` with `(prim)` and `(secondary)` with `(sec)` in regression docs
- remove obsolete replacements from `normalize_table_text`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_687a2aaa56008332956d1c992f29bb74