### PR TITLE
Add HeadHunter jobs link

### DIFF
--- a/src/shared/generator_shared.rs
+++ b/src/shared/generator_shared.rs
@@ -456,8 +456,13 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
                 "📢 [Rust Jobs feed]({})",
                 escape_markdown_url("https://t.me/rust_jobs_feed")
             );
+            let hh = format!(
+                "📝 [Rust HH jobs]({}) — channel with Rust jobs from HeadHunter",
+                escape_markdown_url("https://t.me/rusthhjobs")
+            );
             sec.lines.insert(1, chat);
             sec.lines.insert(2, feed);
+            sec.lines.insert(3, hh);
         }
         if sec
             .title


### PR DESCRIPTION
## Summary
- show an extra 'HeadHunter jobs' link in the Jobs section

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_687f8d39645083329ae96eacbd2edcc0