### PR TITLE
Fail build if last-sent artifact is missing

### DIFF
--- a/.github/workflows/common-delivery.yml
+++ b/.github/workflows/common-delivery.yml
@@ -48,7 +48,10 @@ jobs:
           prev=$(gh run list -w "${{ github.workflow }}" --branch main --status success \
             -L 1 --json databaseId -q '.[0].databaseId' || echo "")
           if [ -n "$prev" ]; then
-            gh run download "$prev" -n last-sent --dir . || true
+            if ! gh run download "$prev" -n last-sent --dir .; then
+              echo "Unable to download last-sent artifact" >&2
+              exit 1
+            fi
           fi
 
       - name: Checkout TWIR

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ writes the generated posts to disk.
 
 The first sent message is automatically pinned, and the service notification is
 removed.
-Production runs store the last processed file in `last_sent.txt` as an artifact and download it on the next run.
+Production runs store the last processed file in `last_sent.txt` as an artifact and download it on the next run. The workflow now fails if this artifact cannot be retrieved.
 
 Responses from Telegram are verified with the `verify-posts` binary.
 The `prod.yml` workflow runs hourly on the zeroth minute and publishes the latest post directly to the main chat. The `retro.yml` workflow builds posts for the last ten issues and uploads


### PR DESCRIPTION
## Summary
- fail pipeline if the last-sent artifact download fails
- document the new behavior in the README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6885b686ed208332ac7d101e1fd755fa