### PR TITLE
Remove extra HeadHunter explanation

### DIFF
--- a/src/shared/generator_shared.rs
+++ b/src/shared/generator_shared.rs
@@ -457,7 +457,7 @@ pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError>
                 escape_markdown_url("https://t.me/rust_jobs_feed")
             );
             let hh = format!(
-                "📝 [Rust HH jobs]({}) — channel with Rust jobs from HeadHunter",
+                "📝 [Rust HH jobs]({})",
                 escape_markdown_url("https://t.me/rusthhjobs")
             );
             sec.lines.insert(1, chat);


### PR DESCRIPTION
## Summary
- shorten the link text for the Rust HH jobs channel in generator

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6885c4fb6f888332ab88e949cd1d52ff