### PR TITLE
Default to compact tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
- "unicode-width 0.2.1",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1771,7 +1771,6 @@ dependencies = [
  "serde_json",
  "teloxide",
  "tempfile",
- "unicode-width 0.1.14",
  "walkdir",
 ]
 
@@ -1792,12 +1791,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "LicenseRef-QQRM-LAPOCHKA"
 [dependencies]
 pulldown-cmark = "0.9"
 teloxide = { version = "0.12", default-features = false }
-unicode-width = "0.1"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ After that you can run the tool manually with:
 cargo run --bin twir-deploy-notify -- twir/content/<file-name>.md
 ```
 
+Pass `--plain` to generate plain text output. Tables are now rendered without
+code fences or extra padding by default.
+
 All files matching `output_*.md` in the current directory are removed before the
 new posts are written.
 

--- a/src/shared/generator_shared.rs
+++ b/src/shared/generator_shared.rs
@@ -422,6 +422,7 @@ pub fn split_posts(text: &str, limit: usize) -> Vec<String> {
 /// # Returns
 /// A vector of validated Telegram Markdown posts or a `ValidationError` if any
 /// post fails validation.
+#[allow(dead_code)]
 pub fn generate_posts(mut input: String) -> Result<Vec<String>, ValidationError> {
     let _title = find_title(&input);
     let number = find_number(&input);
@@ -886,7 +887,7 @@ mod tests {
     fn table_rendering() {
         let input = "Title: Test\nNumber: 1\nDate: 2024-01-01\n\n## Table\n| Name | Score |\n|------|------|\n| Foo | 10 |\n| Bar | 20 |\n";
         let posts = generate_posts(input.to_string()).unwrap();
-        let table = "```\n| Name | Score |\n| Foo  | 10    |\n| Bar  | 20    |\n```";
+        let table = "\\| Name \\| Score \\|\n\\| Foo \\| 10 \\|\n\\| Bar \\| 20 \\|";
         assert!(posts[0].contains(table));
     }
 

--- a/src/shared/parser.rs
+++ b/src/shared/parser.rs
@@ -1,5 +1,4 @@
 use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag};
-use unicode_width::UnicodeWidthStr;
 
 use crate::generator::{escape_markdown_url, format_subheading};
 use teloxide::utils::markdown::escape;
@@ -179,33 +178,18 @@ pub fn parse_sections(text: &str) -> Vec<Section> {
             }
             Event::End(Tag::Table(_)) => {
                 if let Some(ref mut sec) = current {
-                    let mut widths: Vec<usize> = vec![];
-                    for r in &table {
-                        for (i, cell) in r.iter().enumerate() {
-                            let w = UnicodeWidthStr::width(cell.as_str());
-                            if i >= widths.len() {
-                                widths.push(w);
-                            } else if widths[i] < w {
-                                widths[i] = w;
-                            }
-                        }
-                    }
-                    let add_fence = !table.is_empty();
-                    if add_fence {
-                        sec.lines.push("```".to_string());
-                    }
                     for r in table.drain(..) {
-                        let mut line = String::from("|");
+                        let mut line = String::new();
                         for (i, cell) in r.into_iter().enumerate() {
-                            let width = widths[i];
-                            let cell_width = UnicodeWidthStr::width(cell.as_str());
-                            let pad = width.saturating_sub(cell_width);
-                            line.push_str(&format!(" {cell}{} |", " ".repeat(pad)));
+                            if i == 0 {
+                                line.push_str("\\| ");
+                            } else {
+                                line.push_str(" \\| ");
+                            }
+                            line.push_str(&cell);
                         }
+                        line.push_str(" \\|");
                         sec.lines.push(line);
-                    }
-                    if add_fence {
-                        sec.lines.push("```".to_string());
                     }
                 }
             }

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -1,6 +1,6 @@
 use twir_deploy_notify::generator;
 
-use generator::{TELEGRAM_LIMIT, split_posts};
+use generator::{TELEGRAM_LIMIT, generate_posts, split_posts};
 use proptest::prelude::*;
 mod common;
 
@@ -150,4 +150,12 @@ fn jobs_url_simplified() {
     let posts = generator::generate_posts(input.to_string()).unwrap();
     let combined = posts.join("\n");
     assert!(combined.contains("[Rust Job Reddit Thread](https://example.com/thread)"));
+}
+
+#[test]
+fn table_compact_format() {
+    let input = "Title: Test\nNumber: 1\nDate: 2024-01-01\n\n## Table\n| Name | Score |\n|------|------|\n| Foo | 10 |\n| Bar | 20 |\n";
+    let posts = generate_posts(input.to_string()).unwrap();
+    assert!(!posts[0].contains("```"));
+    assert!(posts[0].contains("\\|"));
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -42,20 +42,19 @@ fn regression_table_ascii_aligned() {
     let sections = parse_sections(input);
     assert_eq!(sections.len(), 1);
     let lines = &sections[0].lines;
-    assert!(lines.first().is_some_and(|l| l == "```"));
-    assert!(lines.last().is_some_and(|l| l == "```"));
-    let body = &lines[1..lines.len() - 1];
-    let width = body.first().unwrap().len();
-    let positions: Vec<_> = body
-        .first()
-        .unwrap()
-        .match_indices('|')
-        .map(|(i, _)| i)
-        .collect();
-    for line in body {
-        assert_eq!(line.len(), width);
+    assert!(lines.first().is_none_or(|l| l != "```"));
+    for line in lines {
         assert!(line.is_ascii());
-        let pos: Vec<_> = line.match_indices('|').map(|(i, _)| i).collect();
-        assert_eq!(pos, positions);
+        assert!(line.contains("\\|"));
     }
+}
+
+#[test]
+fn regression_table_compact() {
+    let input = include_str!("regression_table.md");
+    let sections = parse_sections(input);
+    assert_eq!(sections.len(), 1);
+    let lines = &sections[0].lines;
+    assert!(lines.first().is_none_or(|l| l != "```"));
+    assert!(lines.iter().any(|l| l.contains("\\|")));
 }


### PR DESCRIPTION
## Summary
- drop CLI flag for table alignment
- render tables in compact form by default
- remove unused unicode-width dependency
- adjust tests and docs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6886554b9a208332bfd89e49954cd7e3