### PR TITLE
Normalize primary/secondary names in tables

### DIFF
--- a/src/shared/parser.rs
+++ b/src/shared/parser.rs
@@ -64,6 +64,10 @@ fn normalize_table_text(text: &str) -> String {
         .replace("Improvements", "Imp")
         .replace('❌', "x")
         .replace('✅', "v")
+        .replace("(primary)", "prim")
+        .replace("(secondary)", "sec")
+        .replace("primary", "prim")
+        .replace("secondary", "sec")
 }
 
 /// Parse TWIR Markdown into logical sections using `pulldown-cmark`.

--- a/tests/regression_table.md
+++ b/tests/regression_table.md
@@ -1,8 +1,8 @@
 ## Perf
-| (instructions:u)    | mean  | range              | count |
+| (instructions:u)    | mean | range              | count |
 |:--------------------|:----:|:------------------:|------:|
-| Reg x  (primary)    | 0.4% | [0.1%, 0.9%]       |    47 |
-| Reg x  (secondary)  | 0.8% | [0.1%, 2.7%]       |    69 |
-| Imp v  (primary)    | -0.8%| [-4.1%, -0.2%]     |   122 |
-| Imp v  (secondary)  | -0.7%| [-2.5%, -0.0%]     |   143 |
-| All xv (primary)    | -0.5%| [-4.1%, 0.9%]      |   169 |
+| Reg x  prim         | 0.4% | [0.1%, 0.9%]       |    47 |
+| Reg x  sec          | 0.8% | [0.1%, 2.7%]       |    69 |
+| Imp v  prim         | -0.8%| [-4.1%, -0.2%]     |   122 |
+| Imp v  sec          | -0.7%| [-2.5%, -0.0%]     |   143 |
+| All xv prim         | -0.5%| [-4.1%, 0.9%]      |   169 |


### PR DESCRIPTION
## Summary
- shorten "primary" and "secondary" labels during table normalization
- update regression table test data accordingly
- fix column spacing in `regression_table.md`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_6886553fcebc8332aa6dc27302cdffee