### PR TITLE
Restrict CI to trusted users

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -7,9 +7,12 @@ on:
 permissions:
   actions: write
 
+env:
+  TRUSTED_USERS: qqrm,EternaleapFromPit
+
 jobs:
   cancel:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && contains(env.TRUSTED_USERS, github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -11,9 +11,12 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  TRUSTED_USERS: qqrm,EternaleapFromPit
+
 jobs:
   cleanup:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && contains(env.TRUSTED_USERS, github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  TRUSTED_USERS: qqrm,EternaleapFromPit
+
 jobs:
   fmt:
+    if: ${{ github.event_name != 'pull_request' || contains(env.TRUSTED_USERS, github.actor) }}
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_PROGRESS_WHEN: never
@@ -29,6 +33,7 @@ jobs:
       - run: cargo fmt --quiet --all -- --check
 
   check:
+    if: ${{ github.event_name != 'pull_request' || contains(env.TRUSTED_USERS, github.actor) }}
     needs: fmt
     runs-on: ubuntu-latest
     env:
@@ -42,6 +47,7 @@ jobs:
       - run: cargo check --quiet --all-targets --all-features
 
   clippy:
+    if: ${{ github.event_name != 'pull_request' || contains(env.TRUSTED_USERS, github.actor) }}
     needs: check
     runs-on: ubuntu-latest
     env:
@@ -55,6 +61,7 @@ jobs:
       - run: cargo clippy --quiet --all-targets --all-features -- -D warnings
 
   test:
+    if: ${{ github.event_name != 'pull_request' || contains(env.TRUSTED_USERS, github.actor) }}
     needs: clippy
     runs-on: ubuntu-latest
     env:
@@ -68,6 +75,7 @@ jobs:
       - run: cargo test --quiet --lib --bins --all-features -- --test-threads=$(nproc)
 
   machete:
+    if: ${{ github.event_name != 'pull_request' || contains(env.TRUSTED_USERS, github.actor) }}
     needs: test
     runs-on: ubuntu-latest
     env:
@@ -82,7 +90,7 @@ jobs:
       - run: cargo machete
 
   audit:
-    if: github.event_name != 'pull_request' || github.event.inputs.run_audit == 'true'
+    if: github.event_name != 'pull_request' || (github.event.inputs.run_audit == 'true' && contains(env.TRUSTED_USERS, github.actor))
     needs: machete
     runs-on: ubuntu-latest
     env:
@@ -97,6 +105,7 @@ jobs:
       - run: cargo audit --quiet
 
   check-docs:
+    if: ${{ github.event_name != 'pull_request' || contains(env.TRUSTED_USERS, github.actor) }}
     needs: machete
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- only run CI if pull-request author is in `TRUSTED_USERS`
- skip cleanup and cancel workflows when PR authors are not trusted

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo install cargo-machete --quiet`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_688b8930b0908332b07ebf55c60140b5